### PR TITLE
既存UI,Logicの微調整 / Effects編集機能拡張 / MUTE UNMUTE機能追加  (Closes #27)

### DIFF
--- a/client/src/app/providers/Providers.tsx
+++ b/client/src/app/providers/Providers.tsx
@@ -14,6 +14,8 @@ import { DrumPatternProvider } from '@entities/pattern/model/DrumPatternContext'
 import { ScaleModeProvider } from '@entities/scale-mode/model/ScaleModeContext';
 import { SegmentProvider } from '@entities/segment/model/SegmentContext';
 import { TempoProvider } from '@entities/tempo/model/TempoContext';
+import { VolumeProvider } from '@entities/volume/model/VolumeContext';
+import { VolumeEngineBinder } from '@features/volume';
 
 import type { ReactNode } from 'react';
 
@@ -23,10 +25,13 @@ export const Providers = ({ children }: Props) => (
   <GlobalAudioProvider>
     {/* Tone のコンテキストを最優先でエンジンに統一 */}
     <ToneMasterBridge />
-    {/* テンポコンテキストを上位に配置し、Binder を内部で利用 */}
+    {/* テンポ/ボリュームのコンテキストを上位に配置し、Binder を内部で利用 */}
     <TempoProvider>
-      {/* テンポ変更を Tone.Transport に常時反映 */}
-      <TempoTransportBinder />
+      <VolumeProvider>
+        {/* テンポ変更を Tone.Transport に常時反映 */}
+        <TempoTransportBinder />
+        {/* ボリューム変更をエンジンに常時反映 */}
+        <VolumeEngineBinder />
       <AnalysisModeProvider>
         <ModeProvider>
           <RecordingProvider>
@@ -55,6 +60,7 @@ export const Providers = ({ children }: Props) => (
           </RecordingProvider>
         </ModeProvider>
       </AnalysisModeProvider>
+      </VolumeProvider>
     </TempoProvider>
   </GlobalAudioProvider>
 );

--- a/client/src/app/providers/Providers.tsx
+++ b/client/src/app/providers/Providers.tsx
@@ -6,6 +6,7 @@ import { BarCountProvider } from '@entities/bar-count/model/BarCountContext';
 import { CountBarsAndBeatsProvider } from '@entities/count-bars-and-beats/model/CountBarsAndBeatsContext';
 import { EffectsProvider } from '@entities/effects/model/EffectsContext';
 import { ReverbBinder, CutFiltersBinder, CrushBinder, DirtyBinder, CombBinder } from '@features/effects';
+import { TempoTransportBinder } from '@features/tempo';
 import { ToneMasterBridge } from '@features/playback/model/ToneMasterBridge';
 import { ModeProvider } from '@entities/mode/model/ModeContext';
 import { ChordPatternProvider } from '@entities/pattern/model/ChordPatternContext';
@@ -22,10 +23,13 @@ export const Providers = ({ children }: Props) => (
   <GlobalAudioProvider>
     {/* Tone のコンテキストを最優先でエンジンに統一 */}
     <ToneMasterBridge />
-    <AnalysisModeProvider>
-      <ModeProvider>
-        <RecordingProvider>
-          <TempoProvider>
+    {/* テンポコンテキストを上位に配置し、Binder を内部で利用 */}
+    <TempoProvider>
+      {/* テンポ変更を Tone.Transport に常時反映 */}
+      <TempoTransportBinder />
+      <AnalysisModeProvider>
+        <ModeProvider>
+          <RecordingProvider>
             <RecordingUIProvider>
               <SegmentProvider>
                 <BarCountProvider>
@@ -48,9 +52,9 @@ export const Providers = ({ children }: Props) => (
                 </BarCountProvider>
               </SegmentProvider>
             </RecordingUIProvider>
-          </TempoProvider>
-        </RecordingProvider>
-      </ModeProvider>
-    </AnalysisModeProvider>
+          </RecordingProvider>
+        </ModeProvider>
+      </AnalysisModeProvider>
+    </TempoProvider>
   </GlobalAudioProvider>
 );

--- a/client/src/entities/audio/lib/GlobalAudioEngine.ts
+++ b/client/src/entities/audio/lib/GlobalAudioEngine.ts
@@ -13,6 +13,8 @@ export class GlobalAudioEngine {
   private ctx: AudioContext | null = null;
   private masterGain: GainNode | null = null; // 合流点（プリ・エフェクト）
   private outputGain: GainNode | null = null; // 最終出力（ポスト・エフェクト）
+  private masterMuted = false;
+  private prevOutputGain = 1;
 
   private wafPlayer: any | null = null;
   private wafLoaded = false;
@@ -72,7 +74,7 @@ export class GlobalAudioEngine {
       this.masterGain = this.ctx.createGain();
       this.masterGain.gain.value = 1; // プリ段
       this.outputGain = this.ctx.createGain();
-      this.outputGain.gain.value = 1; // マスター音量
+      this.outputGain.gain.value = 1; // マスター音量（mute時は0に退避）
       // 初期はドライ直結
       this.masterGain.connect(this.outputGain);
       this.outputGain.connect(this.ctx.destination);
@@ -157,6 +159,25 @@ export class GlobalAudioEngine {
   get audioContext() { return this.ctx; }
   get player() { return this.wafPlayer; }
   get masterInput(): AudioNode | null { return this.masterGain; }
+
+  // 即時ミュート/解除（現在鳴っている音も即サイレンス化）。
+  async setMasterMuted(muted: boolean) {
+    await this.ensureStarted();
+    if (!this.ctx || !this.outputGain) return;
+    if (muted === this.masterMuted) return;
+    const now = this.ctx.currentTime;
+    if (muted) {
+      this.prevOutputGain = this.outputGain.gain.value;
+      this.outputGain.gain.cancelScheduledValues(now);
+      this.outputGain.gain.setTargetAtTime(0, now, 0.01);
+      this.masterMuted = true;
+    } else {
+      const target = this.prevOutputGain > 0 ? this.prevOutputGain : 1;
+      this.outputGain.gain.cancelScheduledValues(now);
+      this.outputGain.gain.setTargetAtTime(target, now, 0.02);
+      this.masterMuted = false;
+    }
+  }
 
   async unlock() {
     await this.ensureStarted();

--- a/client/src/entities/audio/lib/GlobalAudioEngine.ts
+++ b/client/src/entities/audio/lib/GlobalAudioEngine.ts
@@ -16,6 +16,14 @@ export class GlobalAudioEngine {
   private masterMuted = false;
   private prevOutputGain = 1;
 
+  // Category gains for per-source mute
+  private melodyGain: GainNode | null = null;
+  private drumGain: GainNode | null = null;
+  private chordGain: GainNode | null = null;
+  private melodyMuted = false;
+  private drumMuted = false;
+  private chordMuted = false;
+
   private wafPlayer: any | null = null;
   private wafLoaded = false;
 
@@ -78,6 +86,17 @@ export class GlobalAudioEngine {
       // 初期はドライ直結
       this.masterGain.connect(this.outputGain);
       this.outputGain.connect(this.ctx.destination);
+
+      // Category submixes -> master
+      this.melodyGain = this.ctx.createGain();
+      this.drumGain = this.ctx.createGain();
+      this.chordGain = this.ctx.createGain();
+      this.melodyGain.gain.value = 1;
+      this.drumGain.gain.value = 1;
+      this.chordGain.gain.value = 1;
+      this.melodyGain.connect(this.masterGain);
+      this.drumGain.connect(this.masterGain);
+      this.chordGain.connect(this.masterGain);
     }
     if (this.ctx.state === 'suspended') await this.ctx.resume();
   }
@@ -98,9 +117,10 @@ export class GlobalAudioEngine {
   noteOn(midi: number, velocity = 127, durationSec?: number) {
     if (!this.ctx || !this.wafPlayer || !this.wafLoaded) return null;
     const when = this.ctx.currentTime;
+    const dest = this.melodyGain ?? this.masterGain;
     const v = this.wafPlayer.queueWaveTable(
       this.ctx,
-      this.masterGain,
+      dest,
       _tone_0000_Aspirin_sf2_file,
       when,
       midi,
@@ -159,6 +179,39 @@ export class GlobalAudioEngine {
   get audioContext() { return this.ctx; }
   get player() { return this.wafPlayer; }
   get masterInput(): AudioNode | null { return this.masterGain; }
+
+  // Channel I/O accessors — route new sources here (future: insert per-channel effects)
+  getChannelInput(kind: 'melody' | 'drum' | 'chord'): AudioNode | null {
+    if (kind === 'melody') return this.melodyGain ?? this.masterGain;
+    if (kind === 'drum') return this.drumGain ?? this.masterGain;
+    return this.chordGain ?? this.masterGain;
+  }
+
+  // Per-source mute controls
+  getChannelMuted(kind: 'melody' | 'drum' | 'chord') {
+    if (kind === 'melody') return this.melodyMuted;
+    if (kind === 'drum') return this.drumMuted;
+    return this.chordMuted;
+  }
+
+  async setChannelMuted(kind: 'melody' | 'drum' | 'chord', muted: boolean) {
+    await this.ensureStarted();
+    if (!this.ctx) return;
+    const now = this.ctx.currentTime;
+    const gain = kind === 'melody' ? this.melodyGain : kind === 'drum' ? this.drumGain : this.chordGain;
+    if (gain) {
+      gain.gain.cancelScheduledValues(now);
+      gain.gain.setTargetAtTime(muted ? 0 : 1, now, 0.01);
+    }
+    // Ensure existing sources are routed to proper submixes (not master)
+    if (kind === 'drum') {
+      // Reconnect loop to drum channel if needed
+      this.ensureLoopConnected();
+    }
+    if (kind === 'melody') this.melodyMuted = muted;
+    else if (kind === 'drum') this.drumMuted = muted;
+    else this.chordMuted = muted;
+  }
 
   // 即時ミュート/解除（現在鳴っている音も即サイレンス化）。
   async setMasterMuted(muted: boolean) {
@@ -223,7 +276,8 @@ export class GlobalAudioEngine {
   private ensureLoopConnected() {
     if (!this.masterGain || !this.loopGain) return;
     try { this.loopGain.disconnect(); } catch (_) { /* no-op */ }
-    this.loopGain.connect(this.masterGain);
+    const target = this.drumGain ?? this.masterGain;
+    this.loopGain.connect(target);
   }
 
   private connectMasterToOutput() {

--- a/client/src/entities/audio/model/useChannelsStore.ts
+++ b/client/src/entities/audio/model/useChannelsStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type ChannelKind = 'melody' | 'drum' | 'chord';
+
+type ChannelsState = {
+  melodyMuted: boolean;
+  drumMuted: boolean;
+  chordMuted: boolean;
+  setMuted: (kind: ChannelKind, muted: boolean) => void;
+  toggleMuted: (kind: ChannelKind) => void;
+};
+
+export const useChannelsStore = create<ChannelsState>()(
+  persist(
+    (set, get) => ({
+      melodyMuted: false,
+      drumMuted: false,
+      chordMuted: false,
+      setMuted: (kind, muted) => {
+        if (kind === 'melody') set({ melodyMuted: muted });
+        else if (kind === 'drum') set({ drumMuted: muted });
+        else set({ chordMuted: muted });
+      },
+      toggleMuted: (kind) => {
+        const s = get();
+        if (kind === 'melody') set({ melodyMuted: !s.melodyMuted });
+        else if (kind === 'drum') set({ drumMuted: !s.drumMuted });
+        else set({ chordMuted: !s.chordMuted });
+      },
+    }),
+    { name: 'micrie:channels' }
+  )
+);
+

--- a/client/src/entities/audio/model/usePianoSampler.ts
+++ b/client/src/entities/audio/model/usePianoSampler.ts
@@ -1,9 +1,12 @@
 import { useEffect, useRef } from 'react';
 import * as Tone from 'tone';
 import { useGlobalAudio } from './GlobalAudioContext';
+import type { ChannelKind } from '@/entities/audio/model/useChannelsStore';
 
-let _sampler: Tone.Sampler | null = null;
-let _loaded = false;
+let _samplerMelody: Tone.Sampler | null = null;
+let _samplerChord: Tone.Sampler | null = null;
+let _loadedMelody = false;
+let _loadedChord = false;
 
 const ensureToneContext = (ctx: AudioContext) => {
   if (Tone.getContext().rawContext !== ctx) {
@@ -12,9 +15,7 @@ const ensureToneContext = (ctx: AudioContext) => {
   }
 };
 
-const getOrCreateSampler = () => {
-  if (_sampler) return _sampler;
-  _sampler = new Tone.Sampler({
+const createSampler = () => new Tone.Sampler({
     urls: {
       A1: 'samples/PublicSamples/IvyAudio-Pianoin162_Close/A1.wav',
       A2: 'samples/PublicSamples/IvyAudio-Pianoin162_Close/A2.wav',
@@ -32,12 +33,10 @@ const getOrCreateSampler = () => {
       'D#8': 'samples/PublicSamples/IvyAudio-Pianoin162_Close/Ds8.wav',
     },
     release: 1,
-    onload: () => { if (!_loaded) { _loaded = true; console.log('Piano Sampler loaded'); } },
+    onload: () => {},
   });
-  return _sampler;
-};
 
-export const usePianoSampler = () => {
+export const usePianoSampler = (kind: Exclude<ChannelKind, 'drum'> = 'melody') => {
   const samplerRef = useRef<Tone.Sampler | null>(null);
   const engine = useGlobalAudio();
 
@@ -48,21 +47,30 @@ export const usePianoSampler = () => {
       ensureToneContext(ctx);
 
       // 既存のサンプラーが他Contextなら破棄
-      if (_sampler && (_sampler.context.rawContext !== Tone.getContext().rawContext)) {
-        _sampler.dispose();
-        _sampler = null;
-        _loaded = false;
+      const samplerGlobal = kind === 'melody' ? _samplerMelody : _samplerChord;
+      if (samplerGlobal && (samplerGlobal.context.rawContext !== Tone.getContext().rawContext)) {
+        samplerGlobal.dispose();
+        if (kind === 'melody') { _samplerMelody = null; _loadedMelody = false; }
+        else { _samplerChord = null; _loadedChord = false; }
       }
 
-      const sampler = getOrCreateSampler();
-      // 出力をエンジンの master に接続
+      // インスタンス確保
+      if (kind === 'melody' && !_samplerMelody) _samplerMelody = createSampler();
+      if (kind === 'chord' && !_samplerChord) _samplerChord = createSampler();
+      const sampler = kind === 'melody' ? _samplerMelody! : _samplerChord!;
+
+      // 接続先: 個別チャンネル
       try { sampler.disconnect(); } catch {}
-      const input = engine.masterInput as unknown as AudioNode | null;
+      const input = engine.getChannelInput(kind) as unknown as AudioNode | null;
       if (input) sampler.connect(input as any);
+
+      if (kind === 'melody' && !_loadedMelody) { _loadedMelody = true; console.log('Piano Sampler (melody) ready'); }
+      if (kind === 'chord' && !_loadedChord) { _loadedChord = true; console.log('Piano Sampler (chord) ready'); }
+
       samplerRef.current = sampler;
     })();
     return () => {};
-  }, [engine]);
+  }, [engine, kind]);
 
   return samplerRef;
 };

--- a/client/src/entities/segment/model/SegmentContext.tsx
+++ b/client/src/entities/segment/model/SegmentContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState, useMemo, useEffect } from 'react';
+import React from 'react';
+import { create } from 'zustand';
 
 export type Segment = {
   label: string;
@@ -11,87 +12,75 @@ export type Segment = {
   confidence_rms?: number;
 };
 
-type SegmentContextType = {
+type StoreState = {
   rhythmSegments: Segment[];
   melodySegments: Segment[];
   loopMode: 'rhythm' | 'melody' | 'both';
+  melodyBuffer: AudioBuffer | null;
+  rhythmBuffer: AudioBuffer | null;
+  recMode: 'melody' | 'rhythm';
   setRhythmSegments: (segments: Segment[]) => void;
   setMelodySegments: (segments: Segment[]) => void;
   setLoopMode: (mode: 'rhythm' | 'melody' | 'both') => void;
-  currentSegments: { rhythm: Segment[]; melody: Segment[] };
   updateMelodySegment: (index: number, newData: Partial<Segment>) => void;
   updateRhythmSegment: (index: number, newData: Partial<Segment>) => void;
-  audioBuffers: { melody: AudioBuffer | null; rhythm: AudioBuffer | null };
   setContextAudioBuffer: (mode: 'melody' | 'rhythm', buffer: AudioBuffer | null) => void;
-  currentBuffer: AudioBuffer | null;
-  recMode: 'melody' | 'rhythm';
   setRecMode: (mode: 'melody' | 'rhythm') => void;
 };
 
-const SegmentContext = createContext<SegmentContextType | undefined>(undefined);
+export const useSegmentStore = create<StoreState>((set) => ({
+  rhythmSegments: [],
+  melodySegments: [],
+  loopMode: 'melody',
+  melodyBuffer: null,
+  rhythmBuffer: null,
+  recMode: 'melody',
+  setRhythmSegments: (segments) => set({ rhythmSegments: segments }),
+  setMelodySegments: (segments) => set({ melodySegments: segments }),
+  setLoopMode: (mode) => set({ loopMode: mode }),
+  updateMelodySegment: (index, newData) => set((s) => {
+    const next = [...s.melodySegments];
+    next[index] = { ...next[index], ...newData } as Segment;
+    return { melodySegments: next };
+  }),
+  updateRhythmSegment: (index, newData) => set((s) => {
+    const next = [...s.rhythmSegments];
+    next[index] = { ...next[index], ...newData } as Segment;
+    return { rhythmSegments: next };
+  }),
+  setContextAudioBuffer: (mode, buffer) => set((s) => ({
+    melodyBuffer: mode === 'melody' ? buffer : s.melodyBuffer,
+    rhythmBuffer: mode === 'rhythm' ? buffer : s.rhythmBuffer,
+  })),
+  setRecMode: (mode) => set({ recMode: mode }),
+}));
 
-export const SegmentProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [rhythmSegments, setRhythmSegments] = useState<Segment[]>([]);
-  const [melodySegments, setMelodySegments] = useState<Segment[]>([]);
-  const [loopMode, setLoopMode] = useState<'rhythm' | 'melody' | 'both'>('melody');
-  const [melodyBuffer, setMelodyBuffer] = useState<AudioBuffer | null>(null);
-  const [rhythmBuffer, setRhythmBuffer] = useState<AudioBuffer | null>(null);
-  const [recMode, setRecMode] = useState<'melody' | 'rhythm'>('melody');
+// 互換の Provider（保持のために残すが、Zustand でグローバル保持するため実態はただのパススルー）
+export const SegmentProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => <>{children}</>;
 
-  const setContextAudioBuffer = (mode: 'melody' | 'rhythm', buffer: AudioBuffer | null) => {
-    if (mode === 'melody') setMelodyBuffer(buffer); else setRhythmBuffer(buffer);
+// 互換の Hook: 既存の SegmentContextType 互換のオブジェクトを返す
+export const useSegment = () => {
+  const state = useSegmentStore();
+  const currentBuffer = state.loopMode === 'melody' ? state.melodyBuffer
+    : state.loopMode === 'rhythm' ? state.rhythmBuffer : null;
+  const currentSegments = {
+    rhythm: state.loopMode === 'melody' ? [] : state.rhythmSegments,
+    melody: state.loopMode === 'rhythm' ? [] : state.melodySegments,
   };
-
-  const currentBuffer = useMemo(() => {
-    if (loopMode === 'melody') return melodyBuffer;
-    if (loopMode === 'rhythm') return rhythmBuffer;
-    if (loopMode === 'both') return null;
-    return null;
-  }, [loopMode, melodyBuffer, rhythmBuffer]);
-
-  const currentSegments = useMemo(() => ({
-    rhythm: loopMode === 'melody' ? [] : rhythmSegments,
-    melody: loopMode === 'rhythm' ? [] : melodySegments,
-  }), [loopMode, rhythmSegments, melodySegments]);
-
-  const updateMelodySegment = (index: number, newData: Partial<Segment>) => {
-    setMelodySegments(prev => { const next = [...prev]; next[index] = { ...next[index], ...newData }; return next; });
-  };
-  const updateRhythmSegment = (index: number, newData: Partial<Segment>) => {
-    setRhythmSegments(prev => { const next = [...prev]; next[index] = { ...next[index], ...newData }; return next; });
-  };
-
-  useEffect(() => {
-    console.log('🎛 loopMode:', loopMode);
-    console.log('🎧 melodyBuffer:', melodyBuffer);
-    console.log('🥁 rhythmBuffer:', rhythmBuffer);
-    console.log('📦 currentBuffer:', currentBuffer);
-  }, [loopMode, melodyBuffer, rhythmBuffer, currentBuffer]);
-
-  return (
-    <SegmentContext.Provider value={{
-      rhythmSegments,
-      melodySegments,
-      loopMode,
-      setRhythmSegments,
-      setMelodySegments,
-      setLoopMode,
-      currentSegments,
-      updateMelodySegment,
-      updateRhythmSegment,
-      audioBuffers: { melody: melodyBuffer, rhythm: rhythmBuffer },
-      setContextAudioBuffer,
-      currentBuffer,
-      recMode,
-      setRecMode,
-    }}>
-      {children}
-    </SegmentContext.Provider>
-  );
-};
-
-export const useSegment = (): SegmentContextType => {
-  const context = useContext(SegmentContext);
-  if (!context) throw new Error('useSegment must be used within a SegmentProvider');
-  return context;
+  return {
+    rhythmSegments: state.rhythmSegments,
+    melodySegments: state.melodySegments,
+    loopMode: state.loopMode,
+    setRhythmSegments: state.setRhythmSegments,
+    setMelodySegments: state.setMelodySegments,
+    setLoopMode: state.setLoopMode,
+    currentSegments,
+    updateMelodySegment: state.updateMelodySegment,
+    updateRhythmSegment: state.updateRhythmSegment,
+    audioBuffers: { melody: state.melodyBuffer, rhythm: state.rhythmBuffer },
+    setContextAudioBuffer: state.setContextAudioBuffer,
+    currentBuffer,
+    recMode: state.recMode,
+    setRecMode: state.setRecMode,
+  } as const;
 };

--- a/client/src/entities/tempo/model/TempoContext.tsx
+++ b/client/src/entities/tempo/model/TempoContext.tsx
@@ -1,9 +1,16 @@
 import React, { createContext, useContext, useState } from 'react';
 
+export const TEMPO_MIN = 20;
+export const TEMPO_MAX = 160;
+
 const TempoContext = createContext<{ tempo: number; setTempo: (tempo: number) => void } | null>(null);
 
 export const TempoProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [tempo, setTempo] = useState(90);
+  const [tempo, setTempoState] = useState(90);
+
+  const clamp = (v: number) => Math.min(TEMPO_MAX, Math.max(TEMPO_MIN, v));
+  const setTempo = (v: number) => setTempoState(clamp(v));
+
   return <TempoContext.Provider value={{ tempo, setTempo }}>{children}</TempoContext.Provider>;
 };
 

--- a/client/src/entities/volume/index.ts
+++ b/client/src/entities/volume/index.ts
@@ -1,0 +1,2 @@
+export { VolumeProvider, useVolume, VOLUME_MIN, VOLUME_MAX } from './model/VolumeContext';
+

--- a/client/src/entities/volume/model/VolumeContext.tsx
+++ b/client/src/entities/volume/model/VolumeContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+export const VOLUME_MIN = 0;
+export const VOLUME_MAX = 100;
+const STORAGE_KEY = 'app.volume';
+
+type Ctx = { volume: number; setVolume: (v: number) => void };
+
+const VolumeContext = createContext<Ctx | null>(null);
+
+export const VolumeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const clamp = (v: number) => Math.min(VOLUME_MAX, Math.max(VOLUME_MIN, v));
+  const [volume, setVolumeState] = useState<number>(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw != null) {
+        const parsed = Number(raw);
+        if (!Number.isNaN(parsed)) return clamp(parsed);
+      }
+    } catch {}
+    return 80;
+  });
+
+  const setVolume = (v: number) => setVolumeState(clamp(v));
+
+  useEffect(() => {
+    try { localStorage.setItem(STORAGE_KEY, String(volume)); } catch {}
+  }, [volume]);
+
+  const value = useMemo(() => ({ volume, setVolume }), [volume]);
+  return <VolumeContext.Provider value={value}>{children}</VolumeContext.Provider>;
+};
+
+export const useVolume = () => {
+  const ctx = useContext(VolumeContext);
+  if (!ctx) throw new Error('useVolume must be used within a VolumeProvider');
+  return ctx;
+};
+

--- a/client/src/features/effects/index.ts
+++ b/client/src/features/effects/index.ts
@@ -4,3 +4,4 @@ export { CutFiltersBinder } from './model/CutFiltersBinder';
 export { CrushBinder } from './model/CrushBinder';
 export { DirtyBinder } from './model/DirtyBinder';
 export { CombBinder } from './model/CombBinder';
+export { useEffectsUiStore } from './model/useEffectsUiStore';

--- a/client/src/features/effects/model/useEffectsUiStore.ts
+++ b/client/src/features/effects/model/useEffectsUiStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import type { EffectKey } from '@/entities/effects/model/EffectsContext';
+
+type EffectsUiState = {
+  // 全体の HOLD（HOLD ALL）
+  hold: boolean;
+  setHold: (v: boolean) => void;
+  toggleHold: () => void;
+
+  // 各エフェクトごとの HOLD 状態
+  holdByKey: Partial<Record<EffectKey, boolean>>;
+  setHoldFor: (key: EffectKey, v: boolean) => void;
+  toggleHoldFor: (key: EffectKey) => void;
+};
+
+export const useEffectsUiStore = create<EffectsUiState>((set) => ({
+  hold: false,
+  setHold: (v) => set(() => (v ? { hold: true } : { hold: false, holdByKey: {} })),
+  toggleHold: () => set((s) => {
+    const next = !s.hold;
+    return next ? { hold: true } : { hold: false, holdByKey: {} };
+  }),
+
+  holdByKey: {},
+  setHoldFor: (key, v) => set((s) => ({ holdByKey: { ...s.holdByKey, [key]: v } })),
+  toggleHoldFor: (key) => set((s) => ({ holdByKey: { ...s.holdByKey, [key]: !s.holdByKey[key] } })),
+}));

--- a/client/src/features/effects/ui/EffectsButton.tsx
+++ b/client/src/features/effects/ui/EffectsButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { StyledButton } from '@shared/ui/RectButton';
+
+type Props = {
+  label: string;
+  size?: number; // default square size (px)
+  width?: number; // optional: override width only (px)
+  height?: number; // optional: override height only (px)
+  active?: boolean;
+  onClick?: () => void;
+};
+
+export const EffectsButton: React.FC<Props> = ({ label, size = 40, width, height, active, onClick }) => {
+  const widthPx = width ?? size;
+  const heightPx = height ?? size;
+  return (
+    <StyledButton
+      active={active}
+      onClick={onClick}
+      widthPx={widthPx}
+      style={{
+        height: `${heightPx}px`,
+        margin: 0,
+        padding: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {label}
+    </StyledButton>
+  );
+};
+
+export default EffectsButton;

--- a/client/src/features/effects/ui/EffectsPanel.tsx
+++ b/client/src/features/effects/ui/EffectsPanel.tsx
@@ -1,0 +1,27 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import { StyledArea } from '@shared/ui';
+
+type Props = {
+  children: React.ReactNode;
+  width?: number;
+};
+
+// Glassy outer frame for effects controls
+export const EffectsPanel: React.FC<Props> = ({ children, width = 600 }) => {
+  return (
+    <StyledArea
+      css={{
+        display: 'block',
+        background: 'linear-gradient(135deg, rgba(255,255,255,0.35), rgba(140,194,209,0.25))',
+        width: '100%',
+        maxWidth: width,
+        margin: '12px auto 0',
+      }}
+    >
+      {children}
+    </StyledArea>
+  );
+};
+
+export default EffectsPanel;

--- a/client/src/features/effects/ui/SplitHoldResetButton.tsx
+++ b/client/src/features/effects/ui/SplitHoldResetButton.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+type Props = {
+  width?: number; // default 60px
+  height?: number; // total height; default 64px
+  holdActive?: boolean;
+  onToggleHold?: () => void;
+  onReset?: () => void;
+};
+
+export const SplitHoldResetButton: React.FC<Props> = ({
+  width = 60,
+  height = 64,
+  holdActive,
+  onToggleHold,
+  onReset,
+}) => {
+  const halfHeight = Math.floor((height - 1) / 2); // 1px divider
+  const bottomHeight = height - (halfHeight + 1);
+  return (
+    <Container style={{ width }}>
+      <HalfShell active={!!holdActive} round="top" style={{ height: halfHeight }} onClick={onToggleHold} aria-label="Hold">
+        HOLD
+      </HalfShell>
+      <Divider />
+      <HalfShell active={false} round="bottom" style={{ height: bottomHeight }} onClick={onReset} aria-label="Reset">
+        RESET
+      </HalfShell>
+    </Container>
+  );
+};
+
+export default SplitHoldResetButton;
+
+// 見た目は StyledButton と同等（単一のボタン）だが、内部で2つの半分ボタンを配置
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const HalfShell = styled.button<{ active: boolean; round: 'top' | 'bottom' }>`
+  appearance: none;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-family: "brandon-grotesque", sans-serif;
+  font-weight: 500;
+  font-style: normal;
+  font-size:14px;
+  /* Frosted glass-like background to match vertical fader aesthetics */
+  background: ${({ active }) =>
+    active
+      ? 'linear-gradient(135deg, rgb(156, 244, 220), rgb(72, 255, 151))'
+      : 'linear-gradient(135deg, rgba(255,255,255,0.35), rgba(140,194,209,0.25))'};
+  color: rgba(5, 4, 69, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: ${({ round }) => (round === 'top' ? '10px 10px 0 0' : '0 0 10px 10px')};
+  padding: 0;
+  /* RectButton と同様の凹み具合（active時はinset） */
+  box-shadow: ${({ active }) =>
+    active
+      ? 'inset 0 2px 4px rgba(0, 0, 0, 0.2)'
+      : '0 8px 16px 0 rgba(31, 38, 135, 0.28)'};
+  transition: box-shadow 0.2s ease, transform 0.08s ease;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+
+  &:active {
+    transform: scale(0.96);
+  }
+`;
+
+const Divider = styled.div`
+  height: 1px;
+  background: rgba(255, 255, 255, 0.35);
+  width: 100%;
+`;
+
+// removed separate HalfButton; each half is a real button (HalfShell)

--- a/client/src/features/effects/ui/VerticalFader.tsx
+++ b/client/src/features/effects/ui/VerticalFader.tsx
@@ -5,6 +5,7 @@ type Props = {
     value: number;
     onChange: (v: number) => void;
     onChangeEnd?: (v: number) => void;
+    springBack?: boolean; // ドラッグ終了時に0へ戻す（グローバル切替）
     step?: number;
     fineMultiplier?: number;
     coarseMultiplier?: number;
@@ -23,6 +24,7 @@ export const VerticalFader: React.FC<Props> = ({
     value,
     onChange,
     onChangeEnd,
+    springBack = false,
     step = 0.02,
     fineMultiplier = 0.2,
     coarseMultiplier = 5,
@@ -66,8 +68,13 @@ export const VerticalFader: React.FC<Props> = ({
     const endDrag = useCallback(() => {
         if (!draggingRef.current) return;
         draggingRef.current = false;
-        onChangeEnd?.(lastValueRef.current);
-    }, [onChangeEnd]);
+        if (springBack) {
+            onChange(0);
+            onChangeEnd?.(0);
+        } else {
+            onChangeEnd?.(lastValueRef.current);
+        }
+    }, [springBack, onChange, onChangeEnd]);
 
     useEffect(() => {
         const up = () => endDrag();

--- a/client/src/features/playback/model/ToneMasterBridge.tsx
+++ b/client/src/features/playback/model/ToneMasterBridge.tsx
@@ -12,7 +12,7 @@ export const ToneMasterBridge: React.FC = () => {
     (async () => {
       await engine.ensureStarted();
       const ctx = engine.audioContext;
-      const input = engine.masterInput as unknown as AudioNode | null;
+      const input = engine.getChannelInput('melody') as unknown as AudioNode | null;
       if (!ctx || !input) return;
 
       // Tone の Context をエンジンの AudioContext に統一
@@ -36,4 +36,3 @@ export const ToneMasterBridge: React.FC = () => {
 
   return null;
 };
-

--- a/client/src/features/playback/model/useChordsPlayer.ts
+++ b/client/src/features/playback/model/useChordsPlayer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useCallback } from 'react';
 
 import { usePianoSampler } from '@entities/audio/model/usePianoSampler';
 import { useChordPattern } from '@entities/pattern/model/ChordPatternContext';
@@ -30,6 +30,10 @@ export const useChordsPlayer = () => {
     });
   };
 
-  return { playChords };
-};
+  // 単一コードを所定時間に鳴らす（Part用）
+  const playChordAt = useCallback((notes: string[], time: number, duration: number) => {
+    notes.forEach(note => pianoSamplerRef.current?.triggerAttackRelease(note, duration, time));
+  }, [pianoSamplerRef]);
 
+  return { playChords, playChordAt, chords };
+};

--- a/client/src/features/playback/model/useChordsPlayer.ts
+++ b/client/src/features/playback/model/useChordsPlayer.ts
@@ -7,7 +7,7 @@ type Chord = string[];
 
 export const useChordsPlayer = () => {
   const { chordPattern } = useChordPattern();
-  const pianoSamplerRef = usePianoSampler();
+  const pianoSamplerRef = usePianoSampler('chord');
 
   const patterns: { [key: string]: Chord[] } = useMemo(() => ({
     pattern1: [ ['F4'], ['F4','A4','C5','E5'], ['F4'], ['F4','A4','C5','E5'], ['E4'], ['E4','G#4','B4','D5'], ['E4'], ['E4','G#4','B4','D5'], ['A3'], ['A3','C4','E4','G4'], ['A3'], ['A3','C4','E4','G4'], ['G3'], ['G3','A#3','D4','F4'], ['C4'], ['C4','E4','G4','A#4'] ],

--- a/client/src/features/playback/model/useDrumPlayer.ts
+++ b/client/src/features/playback/model/useDrumPlayer.ts
@@ -65,7 +65,7 @@ export const useDrumPlayer = () => {
     if (!buffer || !ctx) return;
     const source = ctx.createBufferSource();
     source.buffer = buffer;
-    const input = engine.masterInput as unknown as AudioNode | null;
+    const input = engine.getChannelInput('drum') as unknown as AudioNode | null;
     if (input) source.connect(input); else source.connect(ctx.destination);
     try { source.start(time); } catch { /* no-op */ }
   }, [engine]);
@@ -82,7 +82,7 @@ export const useDrumPlayer = () => {
     events.forEach(({ type, time }) => {
       const buffer = buffersRef.current[type]; if (!buffer) return;
       const source = ctx.createBufferSource(); source.buffer = buffer;
-      const input = engine.masterInput as unknown as AudioNode | null;
+      const input = engine.getChannelInput('drum') as unknown as AudioNode | null;
       if (input) source.connect(input); else source.connect(ctx.destination);
       source.start(startTime + time * beatDuration);
     });

--- a/client/src/features/playback/model/useDrumPlayer.ts
+++ b/client/src/features/playback/model/useDrumPlayer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo } from 'react';
+import { useEffect, useRef, useMemo, useCallback } from 'react';
 // import * as Tone from 'tone';
 
 import { useDrumPattern } from '@entities/pattern/model/DrumPatternContext';
@@ -57,18 +57,36 @@ export const useDrumPlayer = () => {
   }, []);
 
   const engine = useGlobalAudio();
+
+  // 単発ヒットをTransportのコールバックtimeに同期して鳴らす
+  const playDrumHit = useCallback((type: DrumType, time: number) => {
+    const buffer = buffersRef.current[type];
+    const ctx = engine.audioContext!;
+    if (!buffer || !ctx) return;
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    const input = engine.masterInput as unknown as AudioNode | null;
+    if (input) source.connect(input); else source.connect(ctx.destination);
+    try { source.start(time); } catch { /* no-op */ }
+  }, [engine]);
+
+  // 現在選択のパターンイベントを返す（timeは拍単位）
+  const getDrumEvents = useCallback(() => {
+    return (drumPatterns[drumPattern] || drumPatterns['basic']);
+  }, [drumPattern, drumPatterns]);
+
+  // 互換: 既存のループ再生（今後は未使用推奨）
   const playDrumLoop = (startTime: number) => {
-    const pattern = drumPatterns[drumPattern] || drumPatterns['basic'];
+    const events = getDrumEvents();
     const ctx = engine.audioContext!; const beatDuration = 60 / tempo;
-    pattern.forEach(({ type, time }) => {
+    events.forEach(({ type, time }) => {
       const buffer = buffersRef.current[type]; if (!buffer) return;
       const source = ctx.createBufferSource(); source.buffer = buffer;
-      // エンジンの master に合流させる
       const input = engine.masterInput as unknown as AudioNode | null;
       if (input) source.connect(input); else source.connect(ctx.destination);
       source.start(startTime + time * beatDuration);
     });
   };
 
-  return { playDrumLoop };
+  return { playDrumLoop, playDrumHit, getDrumEvents };
 };

--- a/client/src/features/playback/model/useMelodyPlayer.ts
+++ b/client/src/features/playback/model/useMelodyPlayer.ts
@@ -14,7 +14,7 @@ const transposeUpTwoOctaves = (note: string): string => {
 
 export const useMelodyPlayer = () => {
   const { scaleMode } = useScaleMode();
-  const pianoSamplerRef = usePianoSampler();
+  const pianoSamplerRef = usePianoSampler('melody');
 
   const mapNoteToScale = (note: string): string => {
     const match = note.match(/^([A-G]#?)(\d)$/);
@@ -33,4 +33,3 @@ export const useMelodyPlayer = () => {
 
   return { playMelody };
 };
-

--- a/client/src/features/playback/model/usePlaybackController.ts
+++ b/client/src/features/playback/model/usePlaybackController.ts
@@ -47,6 +47,7 @@ export const usePlaybackController = () => {
     // Tone.Transport とアプリのテンポを同期
     Tone.getTransport().bpm.value = tempo;
     await GlobalAudioEngine.instance.ensureStarted();
+    await GlobalAudioEngine.instance.setMasterMuted(false);
 
     const loopLengthInBeats = '2m';
     const playOnce = (time: number) => {
@@ -68,6 +69,8 @@ export const usePlaybackController = () => {
   };
 
   const stop = () => {
+    // 即時ミュートして現在鳴っている音も瞬時に無音化
+    GlobalAudioEngine.instance.setMasterMuted(true);
     Tone.getTransport().stop();
     Tone.getTransport().cancel();
     setLoopPlaying(false);

--- a/client/src/features/playback/model/usePlaybackController.ts
+++ b/client/src/features/playback/model/usePlaybackController.ts
@@ -121,10 +121,17 @@ export const usePlaybackController = () => {
     setLoopPlaying(false);
   };
 
+  const reset = () => {
+    // 停止（位置リセット0:0:0）
+    GlobalAudioEngine.instance.setMasterMuted(true);
+    Tone.getTransport().stop();
+    setLoopPlaying(false);
+  };
+
   useEffect(() => {
     const actuallyPlaying = Tone.getTransport().state === 'started';
     setLoopPlaying(actuallyPlaying);
   }, [setLoopPlaying]);
 
-  return { loopPlay, stop, isLoopPlaying };
+  return { loopPlay, stop, reset, isLoopPlaying };
 };

--- a/client/src/features/playback/model/usePlaybackController.ts
+++ b/client/src/features/playback/model/usePlaybackController.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import * as Tone from 'tone';
 
 import { GlobalAudioEngine } from '@entities/audio/lib/GlobalAudioEngine';
@@ -34,45 +34,90 @@ export const usePlaybackController = () => {
 
   useEffect(() => { if (DEBUG) console.log('🎹 quantizedMelody:', quantizedMelody); }, [quantizedMelody]);
 
-  const chordDuration = 60 / tempo / 2;
-  const melodyDuration = 60 / tempo / 4;
+  // 基本単位（楽譜時間 -> 秒 は必要時のみ）
+  const chordDurSec = Tone.Time('8n').toSeconds(); // 0.5 beat
+  const sixteenthSec = Tone.Time('16n').toSeconds();
 
-  const { playChords } = useChordsPlayer();
+  const { playChordAt, chords } = useChordsPlayer();
   const { playMelody } = useMelodyPlayer();
-  const { playDrumLoop } = useDrumPlayer();
+  const { playDrumHit, getDrumEvents } = useDrumPlayer();
+
+  const drumsPartRef = useRef<Tone.Part | null>(null);
+  const chordsPartRef = useRef<Tone.Part | null>(null);
+  const melodyPartRef = useRef<Tone.Part | null>(null);
+
+  // beats値を Bars:Beats:Sixteenths 文字列に変換
+  const beatsToBBS = (beats: number) => {
+    const totalBeats = Math.max(0, beats);
+    const bars = Math.floor(totalBeats / 4);
+    const remBeats = totalBeats - bars * 4;
+    const beatIdx = Math.floor(remBeats);
+    const sixteenth = Math.round((remBeats - beatIdx) * 4);
+    return `${bars}:${beatIdx}:${sixteenth}` as const;
+  };
+
+  // Parts を再構築（内容変化時）
+  useEffect(() => {
+    // 既存破棄
+    drumsPartRef.current?.dispose();
+    chordsPartRef.current?.dispose();
+    melodyPartRef.current?.dispose();
+
+
+    // Drums: 16分グリッドのイベントをPart化
+    const drumEvents = getDrumEvents(); // time in beats
+    const drumItems = drumEvents.map(ev => [beatsToBBS(ev.time), ev.type] as [string, string]);
+    const drumsPart = new Tone.Part((time, type: any) => {
+      playDrumHit(type as any, time);
+    }, drumItems);
+    drumsPart.loop = false; drumsPart.start(0);
+    drumsPartRef.current = drumsPart;
+
+    // Chords: 8分 or 4分ごと（元ロジックに合わせ2m/8=8分? ここでは chordDuration 毎）
+    const chordItems: [string, number][] = chords.map((_, i) => [beatsToBBS(i * 0.5), i]);
+    const chordsPart = new Tone.Part((time, idx: number) => {
+      const chord = chords[idx] ?? [];
+      playChordAt(chord, time, chordDurSec);
+    }, chordItems);
+    chordsPart.loop = false; chordsPart.start(0);
+    chordsPartRef.current = chordsPart;
+
+    // Melody: 16分グリッドの量子化ノート
+    const melodyItems = quantizedMelody.map(({ note, startIndex, length }) => ({
+      t: beatsToBBS(startIndex * 0.25), // 16分単位
+      n: note,
+      d: length * sixteenthSec,
+    }));
+    const melodyPart = new Tone.Part((time, ev: any) => {
+      playMelody(ev.n, time, ev.d);
+    }, melodyItems.map(ev => [ev.t, ev] as [string, any]));
+    melodyPart.loop = false; melodyPart.start(0);
+    melodyPartRef.current = melodyPart;
+
+    return () => {
+      drumsPartRef.current?.dispose(); drumsPartRef.current = null;
+      chordsPartRef.current?.dispose(); chordsPartRef.current = null;
+      melodyPartRef.current?.dispose(); melodyPartRef.current = null;
+    };
+  }, [chords, quantizedMelody, getDrumEvents, playDrumHit, playChordAt, playMelody]);
 
   const loopPlay = async () => {
     if (isLoopPlaying) return;
     if (Tone.getContext().state !== 'running') await Tone.start();
-    // Tone.Transport とアプリのテンポを同期
     Tone.getTransport().bpm.value = tempo;
     await GlobalAudioEngine.instance.ensureStarted();
     await GlobalAudioEngine.instance.setMasterMuted(false);
-
-    const loopLengthInBeats = '2m';
-    const playOnce = (time: number) => {
-      playChords(time, chordDuration);
-      playDrumLoop(time);
-      quantizedMelody.forEach(({ note, startIndex, length }) => {
-        const startTime = time + melodyDuration * startIndex;
-        const noteDuration = melodyDuration * length;
-        playMelody(note, startTime, noteDuration);
-      });
-    };
-
-    Tone.getTransport().stop();
-    Tone.getTransport().cancel();
-    const alignedStart = Tone.getTransport().seconds;
-    Tone.getTransport().scheduleRepeat((time) => playOnce(time), loopLengthInBeats, alignedStart);
-    Tone.getTransport().start(undefined, alignedStart);
+    // ループ設定（Transport に任せる）
+    Tone.getTransport().loop = true;
+    Tone.getTransport().loopEnd = '2m';
+    Tone.getTransport().start();
     setLoopPlaying(true);
   };
 
   const stop = () => {
-    // 即時ミュートして現在鳴っている音も瞬時に無音化
+    // 一時停止（位置保持）
     GlobalAudioEngine.instance.setMasterMuted(true);
-    Tone.getTransport().stop();
-    Tone.getTransport().cancel();
+    Tone.getTransport().pause();
     setLoopPlaying(false);
   };
 

--- a/client/src/features/segment-edit/ui/MelodySegmentEditor.tsx
+++ b/client/src/features/segment-edit/ui/MelodySegmentEditor.tsx
@@ -4,6 +4,7 @@ import { TiArrowSortedUp, TiArrowSortedDown } from "react-icons/ti";
 import * as Tone from "tone";
 
 import { useScaleMode } from "@entities/scale-mode/model/ScaleModeContext";
+import { useGlobalAudio } from "@entities/audio/model/GlobalAudioContext";
 import { useSegment } from "@entities/segment/model/SegmentContext";
 
 const NoteControlGroup = styled.div`
@@ -60,6 +61,7 @@ type Props = { barIndex: number; width: number };
 const MelodySegmentEditor: React.FC<Props> = ({ barIndex, width }) => {
   const { currentSegments, updateMelodySegment } = useSegment();
   const { scaleMode } = useScaleMode();
+  const engine = useGlobalAudio();
 
   const shiftNote = (index: number, semitone: number) => {
     const note = currentSegments.melody[index].note;
@@ -71,6 +73,8 @@ const MelodySegmentEditor: React.FC<Props> = ({ barIndex, width }) => {
       const newMidi = midi + semitone;
       const newNote = Tone.Frequency(newMidi, "midi").toNote();
       updateMelodySegment(index, { note: newNote, label: newNote });
+      // プレビュー再生時にマスターがミュートされていると無音になるため、念のため解除
+      (async () => { try { await engine.setMasterMuted(false); } catch {} })();
       synth.triggerAttackRelease(newNote, "8n");
     } catch (error) { console.warn("Note conversion error:", error); }
   };

--- a/client/src/features/segment-edit/ui/MelodySegmentEditor.tsx
+++ b/client/src/features/segment-edit/ui/MelodySegmentEditor.tsx
@@ -73,9 +73,17 @@ const MelodySegmentEditor: React.FC<Props> = ({ barIndex, width }) => {
       const newMidi = midi + semitone;
       const newNote = Tone.Frequency(newMidi, "midi").toNote();
       updateMelodySegment(index, { note: newNote, label: newNote });
-      // プレビュー再生時にマスターがミュートされていると無音になるため、念のため解除
-      (async () => { try { await engine.setMasterMuted(false); } catch {} })();
-      synth.triggerAttackRelease(newNote, "8n");
+      // プレビュー再生: ユーザー操作内で AudioContext/Tone を必ず起動し、ミュート解除してから発音
+      (async () => {
+        try {
+          if ((Tone.getContext() as any).state !== 'running') {
+            await Tone.start();
+          }
+        } catch {}
+        try { await engine.ensureStarted(); } catch {}
+        try { await engine.setMasterMuted(false); } catch {}
+        try { synth.triggerAttackRelease(newNote, "8n"); } catch {}
+      })();
     } catch (error) { console.warn("Note conversion error:", error); }
   };
 

--- a/client/src/features/segment-edit/ui/RhythmSegmentEditor.tsx
+++ b/client/src/features/segment-edit/ui/RhythmSegmentEditor.tsx
@@ -63,11 +63,21 @@ export const RhythmSegmentEditor = ({ barIndex }: Props) => {
     const newIdx = (currentIdx + direction + drumOrder.length) % drumOrder.length;
     const newNote = drumOrder[newIdx];
     updateRhythmSegment(index, { label: newNote });
-    // プレビュー再生のためマスターのミュートを解除
-    (async () => { try { await engine.setMasterMuted(false); } catch {} })();
-    if (newNote === "kick") synths.kick.triggerAttackRelease("C1", "8n");
-    else if (newNote === "snare") synths.snare.triggerAttackRelease("8n");
-    else if (newNote === "hihat") synths.hihat.triggerAttackRelease("16n");
+    // プレビュー再生のため、AudioContext/Tone を確実に起動しミュート解除後に再生
+    (async () => {
+      try {
+        if ((Tone.getContext() as any).state !== 'running') {
+          await Tone.start();
+        }
+      } catch {}
+      try { await engine.ensureStarted(); } catch {}
+      try { await engine.setMasterMuted(false); } catch {}
+      try {
+        if (newNote === "kick") synths.kick.triggerAttackRelease("C1", "8n");
+        else if (newNote === "snare") synths.snare.triggerAttackRelease("8n");
+        else if (newNote === "hihat") synths.hihat.triggerAttackRelease("16n");
+      } catch {}
+    })();
   };
 
   const previousNotesRef = React.useRef<string[]>([]);

--- a/client/src/features/segment-edit/ui/RhythmSegmentEditor.tsx
+++ b/client/src/features/segment-edit/ui/RhythmSegmentEditor.tsx
@@ -4,6 +4,7 @@ import { TiArrowSortedUp, TiArrowSortedDown } from "react-icons/ti";
 import * as Tone from "tone";
 
 import { useSegment } from "@entities/segment/model/SegmentContext";
+import { useGlobalAudio } from "@entities/audio/model/GlobalAudioContext";
 
 const GlassButtonUp = styled.button`
   background: rgba(255, 255, 255, 0.1);
@@ -53,6 +54,7 @@ const synths = {
 
 export const RhythmSegmentEditor = ({ barIndex }: Props) => {
   const { currentSegments, updateRhythmSegment } = useSegment();
+  const engine = useGlobalAudio();
 
   const shiftDrum = (index: number, direction: number) => {
     const label = currentSegments.rhythm[index].label;
@@ -61,6 +63,8 @@ export const RhythmSegmentEditor = ({ barIndex }: Props) => {
     const newIdx = (currentIdx + direction + drumOrder.length) % drumOrder.length;
     const newNote = drumOrder[newIdx];
     updateRhythmSegment(index, { label: newNote });
+    // プレビュー再生のためマスターのミュートを解除
+    (async () => { try { await engine.setMasterMuted(false); } catch {} })();
     if (newNote === "kick") synths.kick.triggerAttackRelease("C1", "8n");
     else if (newNote === "snare") synths.snare.triggerAttackRelease("8n");
     else if (newNote === "hihat") synths.hihat.triggerAttackRelease("16n");
@@ -95,4 +99,3 @@ export const RhythmSegmentEditor = ({ barIndex }: Props) => {
     </div>
   );
 };
-

--- a/client/src/features/tempo/index.ts
+++ b/client/src/features/tempo/index.ts
@@ -1,2 +1,2 @@
-export { default as TempoControlButton } from './ui/TempoControlButton';
+export { default as TempoControl } from './ui/TempoControl';
 

--- a/client/src/features/tempo/index.ts
+++ b/client/src/features/tempo/index.ts
@@ -1,2 +1,2 @@
 export { default as TempoControl } from './ui/TempoControl';
-
+export { TempoTransportBinder } from './model/TempoTransportBinder';

--- a/client/src/features/tempo/model/TempoTransportBinder.tsx
+++ b/client/src/features/tempo/model/TempoTransportBinder.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import * as Tone from 'tone';
+
+import { useTempo } from '@entities/tempo/model/TempoContext';
+
+// Keep Tone.Transport BPM in sync with global tempo context across all pages.
+export const TempoTransportBinder: React.FC = () => {
+  const { tempo } = useTempo();
+
+  useEffect(() => {
+    try {
+      Tone.getTransport().bpm.value = tempo;
+    } catch {}
+  }, [tempo]);
+
+  return null;
+};
+

--- a/client/src/features/tempo/ui/TempoControl.tsx
+++ b/client/src/features/tempo/ui/TempoControl.tsx
@@ -5,40 +5,39 @@ import 'rc-slider/assets/index.css';
 import { useState, useEffect } from 'react';
 
 import { useTempo } from '@entities/tempo/model/TempoContext';
-import { StyledButton } from '@shared/ui/RectButton';
 
 type Props = {
-  isOpen: boolean;
-  onToggle: () => void;
+  // Legacy props kept for compatibility; ignored now
+  isOpen?: boolean;
+  onToggle?: () => void;
 };
 
 const Wrapper = styled.div`
-  position: relative;
   display: inline-block;
 `;
 
-const Dropdown = styled.div`
-  position: absolute;
-  top: 100%;
-  left: 0;
-  background: white;
-  border-radius: 6px;
-  margin-top: 4px;
-  padding: 12px;
-  width: 200px;
-  z-index: 100;
-`;
-
 const Label = styled.label`
+  font-family: "brandon-grotesque", sans-serif;
+  font-weight: 500;
+  font-style: normal;
   font-size: 14px;
+  color: rgba(5, 4, 69, 0.8);
   margin-bottom: 4px;
   display: block;
 `;
 
 const NumberInput = styled.input`
   width: 50%;
+  font-family: "brandon-grotesque", sans-serif;
+  font-weight: 500;
+  font-style: normal;
   font-size: 16px;
+  color: rgba(5, 4, 69, 0.8);
   text-align: center;
+  background: transparent;
+  border: none;
+  outline: none;
+  width: 34px;
 `;
 
 const StyledRcSliderWrapper = styled.div`
@@ -67,7 +66,7 @@ const StyledRcSliderWrapper = styled.div`
   }
 `;
 
-const TempoControlButton = ({ isOpen, onToggle }: Props) => {
+const TempoControlButton = (_props: Props) => {
   const { tempo, setTempo } = useTempo();
   const [tempoInput, setTempoInput] = useState(String(tempo));
 
@@ -86,28 +85,21 @@ const TempoControlButton = ({ isOpen, onToggle }: Props) => {
 
   return (
     <Wrapper>
-      <StyledButton onClick={onToggle} active={isOpen} style={{ width: '160px', justifyContent: 'center' }}>
-        TEMPO: BPM {tempo}
-      </StyledButton>
-      {isOpen && (
-        <Dropdown>
-          <Label>TEMPO: {tempo} BPM</Label>
-          <StyledRcSliderWrapper>
-            <RcSlider
-              min={20}
-              max={160}
-              value={tempo}
-              onChange={(value) => {
-                if (typeof value === 'number') {
-                  setTempo(value);
-                  setTempoInput(String(value));
-                }
-              }}
-            />
-          </StyledRcSliderWrapper>
-          <NumberInput type="text" min="20" max="160" value={tempoInput} onChange={handleInputChange} />
-        </Dropdown>
-      )}
+      <Label>TEMPO <NumberInput type="text" min="20" max="160" value={tempoInput} onChange={handleInputChange} />BPM</Label>
+      <StyledRcSliderWrapper>
+        <RcSlider
+          min={20}
+          max={160}
+          value={tempo}
+          onChange={(value) => {
+            if (typeof value === 'number') {
+              setTempo(value);
+              setTempoInput(String(value));
+            }
+          }}
+        />
+      </StyledRcSliderWrapper>
+
     </Wrapper>
   );
 };

--- a/client/src/features/tempo/ui/TempoControl.tsx
+++ b/client/src/features/tempo/ui/TempoControl.tsx
@@ -4,7 +4,7 @@ import RcSlider from 'rc-slider';
 import 'rc-slider/assets/index.css';
 import { useState, useEffect } from 'react';
 
-import { useTempo } from '@entities/tempo/model/TempoContext';
+import { useTempo, TEMPO_MIN, TEMPO_MAX } from '@entities/tempo/model/TempoContext';
 
 type Props = {
   // Legacy props kept for compatibility; ignored now
@@ -72,11 +72,21 @@ const TempoControlButton = (_props: Props) => {
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    if (/^\d*$/.test(value)) {
-      setTempoInput(value);
-      const numeric = Number(value);
-      if (numeric >= 20 && numeric <= 160) setTempo(numeric);
+    // 途中入力は自由（数字のみ許可）。コンテキストは更新しない。
+    if (!/^\d*$/.test(value)) return; // ignore non-digits
+    setTempoInput(value);
+  };
+
+  const commitInput = () => {
+    if (tempoInput === '') {
+      setTempo(TEMPO_MIN);
+      setTempoInput(String(TEMPO_MIN));
+      return;
     }
+    const numeric = Number(tempoInput);
+    const clamped = Math.min(TEMPO_MAX, Math.max(TEMPO_MIN, numeric));
+    setTempo(clamped);
+    setTempoInput(String(clamped));
   };
 
   useEffect(() => {
@@ -85,11 +95,23 @@ const TempoControlButton = (_props: Props) => {
 
   return (
     <Wrapper>
-      <Label>TEMPO <NumberInput type="text" min="20" max="160" value={tempoInput} onChange={handleInputChange} />BPM</Label>
+      <Label>
+        TEMPO
+        <NumberInput
+          type="text"
+          min={String(TEMPO_MIN)}
+          max={String(TEMPO_MAX)}
+          value={tempoInput}
+          onChange={handleInputChange}
+          onBlur={commitInput}
+          onKeyDown={(e) => { if (e.key === 'Enter') commitInput(); }}
+        />
+        BPM
+      </Label>
       <StyledRcSliderWrapper>
         <RcSlider
-          min={20}
-          max={160}
+          min={TEMPO_MIN}
+          max={TEMPO_MAX}
           value={tempo}
           onChange={(value) => {
             if (typeof value === 'number') {

--- a/client/src/features/volume/index.ts
+++ b/client/src/features/volume/index.ts
@@ -1,0 +1,2 @@
+export { default as VolumeControl } from './ui/VolumeControl';
+

--- a/client/src/features/volume/index.ts
+++ b/client/src/features/volume/index.ts
@@ -1,2 +1,2 @@
 export { default as VolumeControl } from './ui/VolumeControl';
-
+export { VolumeEngineBinder } from './model/VolumeEngineBinder';

--- a/client/src/features/volume/model/VolumeEngineBinder.tsx
+++ b/client/src/features/volume/model/VolumeEngineBinder.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useGlobalAudio } from '@entities/audio/model/GlobalAudioContext';
+import { useVolume } from '@entities/volume/model/VolumeContext';
+
+// Keep GlobalAudioEngine master volume in sync with volume context across all pages.
+export const VolumeEngineBinder: React.FC = () => {
+  const { volume } = useVolume();
+  const engine = useGlobalAudio();
+
+  useEffect(() => {
+    (async () => {
+      try { await engine.ensureStarted(); } catch {}
+      try { engine.setMasterVolume(Math.max(0, Math.min(1, volume / 100))); } catch {}
+    })();
+  }, [volume, engine]);
+
+  return null;
+};
+

--- a/client/src/features/volume/ui/VolumeControl.tsx
+++ b/client/src/features/volume/ui/VolumeControl.tsx
@@ -1,15 +1,13 @@
-// TEMPOの値を調整するためのボタンとドロップダウンUIコンポーネント（初期実装）
+// VOLUMEの値を調整するためのボタンと入力・スライダーのUIコンポーネント（UIのみ）
 import styled from '@emotion/styled';
 import RcSlider from 'rc-slider';
 import 'rc-slider/assets/index.css';
 import { useState, useEffect } from 'react';
-
-import { useTempo, TEMPO_MIN, TEMPO_MAX } from '@entities/tempo/model/TempoContext';
+import { useGlobalAudio } from '@entities/audio/model/GlobalAudioContext';
 
 type Props = {
-  // Legacy props kept for compatibility; ignored now
-  isOpen?: boolean;
-  onToggle?: () => void;
+  // 将来的に外部制御したい場合のための拡張余地
+  initialValue?: number; // 0-100
 };
 
 const Wrapper = styled.div`
@@ -66,64 +64,78 @@ const StyledRcSliderWrapper = styled.div`
   }
 `;
 
-const TempoControlButton = (_props: Props) => {
-  const { tempo, setTempo } = useTempo();
-  const [tempoInput, setTempoInput] = useState(String(tempo));
+const MIN = 0;
+const MAX = 100;
+
+const VolumeControl = ({ initialValue = 80 }: Props) => {
+  const clamp = (v: number) => Math.min(MAX, Math.max(MIN, v));
+  const engine = useGlobalAudio();
+  const [volume, setVolume] = useState<number>(clamp(initialValue));
+  const [volumeInput, setVolumeInput] = useState<string>(String(clamp(initialValue)));
+
+  // AudioGraph が未初期化の場合に備え、最初に起動（ユーザー操作内想定）
+  useEffect(() => {
+    (async () => { try { await engine.ensureStarted(); } catch { } })();
+  }, [engine]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    // 途中入力は自由（数字のみ許可）。コンテキストは更新しない。
-    if (!/^\d*$/.test(value)) return; // ignore non-digits
-    setTempoInput(value);
+    if (!/^\d*$/.test(value)) return; // 数字のみ許可
+    setVolumeInput(value);
   };
 
   const commitInput = () => {
-    if (tempoInput === '') {
-      setTempo(TEMPO_MIN);
-      setTempoInput(String(TEMPO_MIN));
+    if (volumeInput === '') {
+      setVolume(MIN);
+      setVolumeInput(String(MIN));
       return;
     }
-    const numeric = Number(tempoInput);
-    const clamped = Math.min(TEMPO_MAX, Math.max(TEMPO_MIN, numeric));
-    setTempo(clamped);
-    setTempoInput(String(clamped));
+    const numeric = Number(volumeInput);
+    const clamped = clamp(numeric);
+    setVolume(clamped);
+    setVolumeInput(String(clamped));
   };
 
   useEffect(() => {
-    setTempoInput(String(tempo));
-  }, [tempo]);
+    setVolumeInput(String(volume));
+  }, [volume]);
+
+  // エンジン連動：ボリュームをマスターに反映（0.0 - 1.0）
+  useEffect(() => {
+    const v = clamp(volume) / 100;
+    try { engine.setMasterVolume(v); } catch { }
+  }, [volume, engine]);
 
   return (
     <Wrapper>
       <Label>
-        TEMPO
+        VOLUME
         <NumberInput
           type="text"
-          min={String(TEMPO_MIN)}
-          max={String(TEMPO_MAX)}
-          value={tempoInput}
+          min={String(MIN)}
+          max={String(MAX)}
+          value={volumeInput}
           onChange={handleInputChange}
           onBlur={commitInput}
           onKeyDown={(e) => { if (e.key === 'Enter') commitInput(); }}
         />
-        BPM
       </Label>
       <StyledRcSliderWrapper>
         <RcSlider
-          min={TEMPO_MIN}
-          max={TEMPO_MAX}
-          value={tempo}
+          min={MIN}
+          max={MAX}
+          value={volume}
           onChange={(value) => {
             if (typeof value === 'number') {
-              setTempo(value);
-              setTempoInput(String(value));
+              const c = clamp(value);
+              setVolume(c);
+              setVolumeInput(String(c));
             }
           }}
         />
       </StyledRcSliderWrapper>
-
     </Wrapper>
   );
 };
 
-export default TempoControlButton;
+export default VolumeControl;

--- a/client/src/features/volume/ui/VolumeControl.tsx
+++ b/client/src/features/volume/ui/VolumeControl.tsx
@@ -4,11 +4,9 @@ import RcSlider from 'rc-slider';
 import 'rc-slider/assets/index.css';
 import { useState, useEffect } from 'react';
 import { useGlobalAudio } from '@entities/audio/model/GlobalAudioContext';
+import { useVolume, VOLUME_MIN as MIN, VOLUME_MAX as MAX } from '@entities/volume/model/VolumeContext';
 
-type Props = {
-  // 将来的に外部制御したい場合のための拡張余地
-  initialValue?: number; // 0-100
-};
+type Props = {};
 
 const Wrapper = styled.div`
   display: inline-block;
@@ -64,14 +62,11 @@ const StyledRcSliderWrapper = styled.div`
   }
 `;
 
-const MIN = 0;
-const MAX = 100;
-
-const VolumeControl = ({ initialValue = 80 }: Props) => {
-  const clamp = (v: number) => Math.min(MAX, Math.max(MIN, v));
+const VolumeControl = (_props: Props) => {
   const engine = useGlobalAudio();
-  const [volume, setVolume] = useState<number>(clamp(initialValue));
-  const [volumeInput, setVolumeInput] = useState<string>(String(clamp(initialValue)));
+  const { volume, setVolume } = useVolume();
+  const clamp = (v: number) => Math.min(MAX, Math.max(MIN, v));
+  const [volumeInput, setVolumeInput] = useState<string>(String(volume));
 
   // AudioGraph が未初期化の場合に備え、最初に起動（ユーザー操作内想定）
   useEffect(() => {
@@ -100,11 +95,7 @@ const VolumeControl = ({ initialValue = 80 }: Props) => {
     setVolumeInput(String(volume));
   }, [volume]);
 
-  // エンジン連動：ボリュームをマスターに反映（0.0 - 1.0）
-  useEffect(() => {
-    const v = clamp(volume) / 100;
-    try { engine.setMasterVolume(v); } catch { }
-  }, [volume, engine]);
+  // エンジン連動は VolumeEngineBinder に委譲
 
   return (
     <Wrapper>

--- a/client/src/pages/create/ui/CreatePage.tsx
+++ b/client/src/pages/create/ui/CreatePage.tsx
@@ -14,6 +14,7 @@ import { ControlPanel } from "@widgets/create/control-panel";
 import { DeveloperToolsPanel } from "@widgets/create/developer-tools-panel";
 import { ModeAndRecGroup } from "@widgets/create/mode-and-rec-group";
 import { TopNav } from "@widgets/top-nav";
+import { TopPlaybackBar } from "@widgets/top-playback-bar";
 import { WaveformDisplay } from "@widgets/waveform";
 
 export const CreatePage = () => {
@@ -59,6 +60,7 @@ export const CreatePage = () => {
     <div css={glassBackground}>
       <RealtimeLabel label={realtimeLabel} />
       <TopNav />
+      <TopPlaybackBar />
       <ModeAndRecGroup
         onToggleRecording={handleToggleRecording}
       />

--- a/client/src/pages/melody/ui/MelodyPage.tsx
+++ b/client/src/pages/melody/ui/MelodyPage.tsx
@@ -1,13 +1,14 @@
 /** @jsxImportSource @emotion/react */
 import { glassBackground } from "@shared/styles/glassBackground";
 import { TopNav } from "@widgets/top-nav/ui/TopNav";
+import { TopPlaybackBar } from "@widgets/top-playback-bar";
 
 export const MelodyPage = () => {
   return (
     <div css={glassBackground}>
       {/* ナビゲーション */}
       <TopNav />
+      <TopPlaybackBar />
     </div>
   );
 };
-

--- a/client/src/pages/play/ui/PlayPage.tsx
+++ b/client/src/pages/play/ui/PlayPage.tsx
@@ -5,61 +5,120 @@ import { useEffect } from "react";
 import { useGlobalAudio } from "@entities/audio/model/GlobalAudioContext";
 import { useEffects, type EffectKey } from "@entities/effects/model/EffectsContext";
 import { VerticalFader } from "@features/effects/ui/VerticalFader";
+import { useEffectsUiStore } from "@/features/effects";
+import EffectsButton from "@features/effects/ui/EffectsButton";
 import { glassBackground } from "@shared/styles/glassBackground";
+import EffectsPanel from "@features/effects/ui/EffectsPanel";
+import SplitHoldResetButton from "@features/effects/ui/SplitHoldResetButton";
 import { TopNav } from "@widgets/top-nav/ui/TopNav";
 import { TopPlaybackBar } from "@widgets/top-playback-bar";
+import { useChannelsStore } from "@/entities/audio/model/useChannelsStore";
 
 
 const LABELS: EffectKey[] = ["CRUSH", "COMB", "HICUT", "LOWCUT", "REVERB", "DIRTY"];
 
-const Faders = () => {
+type FadersProps = { springBack: boolean };
+const Faders = ({ springBack }: FadersProps) => {
   const { effects, setEffect } = useEffects();
+  const holdAll = useEffectsUiStore((s) => s.hold);
+  const holdBy = useEffectsUiStore((s) => s.holdByKey);
+  const toggleHoldFor = useEffectsUiStore((s) => s.toggleHoldFor);
+
   return (
-    <div
-      css={{
-        backdropFilter: "blur(20px)",
-        WebkitBackdropFilter: "blur(20px)",
-        borderRadius: 16,
-        border: "1px solid rgba(255, 255, 255, 0.18)",
-        boxShadow: "0 8px 16px 0 rgba(31, 38, 135, 0.37)",
-        background: "linear-gradient(135deg, rgba(255,255,255,0.35), rgba(140,194,209,0.25))",
-        padding: 16,
-        width: 600,
-        margin: "12px auto 0",
-      }}
-    >
-      <div css={{ display: "flex", gap: "12px", alignItems: "flex-end", justifyContent: "center" }}>
-        {LABELS.map((label) => (
-          <VerticalFader
-            key={label}
-            label={label}
-            value={effects[label]}
-            onChange={(v) => setEffect(label, v)}
-            width={60}
-            height={180}
-          />
-        ))}
-      </div>
+    <div css={{ display: 'flex', gap: '12px', alignItems: 'flex-end', justifyContent: 'center' }}>
+      {LABELS.map((label) => {
+        const isHeld = !!holdAll || !!holdBy[label];
+        const faderSpringBack = springBack && !isHeld; // 全体指定に対し、HOLD（全体/個別）が有効ならスプリングバック無効
+        return (
+          <div key={label} css={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+            <VerticalFader
+              label={label}
+              value={effects[label]}
+              onChange={(v) => setEffect(label, v)}
+              springBack={faderSpringBack}
+              width={60}
+              height={180}
+            />
+            <SplitHoldResetButton
+              width={60}
+              height={64}
+              holdActive={isHeld}
+              onToggleHold={() => toggleHoldFor(label)}
+              onReset={() => setEffect(label, 0)}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 };
 
 export const PlayPage = () => {
   const engine = useGlobalAudio();
+  const hold = useEffectsUiStore((s) => s.hold);
+  const toggleHold = useEffectsUiStore((s) => s.toggleHold);
+  const { setEffect, setMany } = useEffects();
+  const melodyMuted = useChannelsStore((s) => s.melodyMuted);
+  const drumMuted = useChannelsStore((s) => s.drumMuted);
+  const chordMuted = useChannelsStore((s) => s.chordMuted);
+  const toggleMuted = useChannelsStore((s) => s.toggleMuted);
+
+  const resetAll = () => {
+    LABELS.forEach((label) => setEffect(label, 0));
+  };
+
+  const randomAll = () => {
+    const patch: Partial<Record<EffectKey, number>> = {};
+    LABELS.forEach((label) => { patch[label] = Math.random(); });
+    setMany(patch);
+  };
 
   useEffect(() => {
     (async () => {
       await engine.ensureStarted();
       // ここでは停止や切断はしない。画面遷移しても継続再生させるため。
+      // ストアのミュート状態をエンジンへ同期
+      await engine.setChannelMuted('melody', melodyMuted);
+      await engine.setChannelMuted('drum', drumMuted);
+      await engine.setChannelMuted('chord', chordMuted);
     })();
   }, [engine]);
+
+  // ミュート状態が変わったらエンジンに反映
+  useEffect(() => { engine.setChannelMuted('melody', melodyMuted); }, [engine, melodyMuted]);
+  useEffect(() => { engine.setChannelMuted('drum', drumMuted); }, [engine, drumMuted]);
+  useEffect(() => { engine.setChannelMuted('chord', chordMuted); }, [engine, chordMuted]);
 
   return (
     <div css={glassBackground}>
       {/* ナビゲーション */}
       <TopNav />
       <TopPlaybackBar />
-      <Faders />
+
+      <EffectsPanel>
+
+        <div
+          css={{
+            display: "flex",
+            justifyContent: "center",
+            // alignItems: "center",
+            gap: 12,
+          }}
+        >
+          {/* 左側：RANDOM ALL（右側ボタン列と同じ幅・UI） */}
+          <div css={{ display: "flex", flexDirection: "column", gap: 12, alignItems: 'center', width: 60 }}>
+            <EffectsButton label="RAND ALL" size={120} width={60} onClick={randomAll} />
+            <EffectsButton label="MELODY" size={32} width={60} active={melodyMuted} onClick={() => toggleMuted('melody')} />
+            <EffectsButton label="CHORD" size={32} width={60} active={chordMuted} onClick={() => toggleMuted('chord')} />
+            <EffectsButton label="DRUM" size={32} width={60} active={drumMuted} onClick={() => toggleMuted('drum')} />
+          </div>
+          <Faders springBack={!hold} />
+          <div css={{ display: "flex", flexDirection: "column", gap: 12, alignItems: 'center', width: 60 }}>
+            <EffectsButton label="HOLD ALL" size={120} width={60} active={hold} onClick={toggleHold} />
+            <EffectsButton label="RESET ALL" size={120} width={60} onClick={resetAll} />
+          </div>
+        </div>
+      </EffectsPanel>
     </div>
   );
 };

--- a/client/src/pages/play/ui/PlayPage.tsx
+++ b/client/src/pages/play/ui/PlayPage.tsx
@@ -7,6 +7,7 @@ import { useEffects, type EffectKey } from "@entities/effects/model/EffectsConte
 import { VerticalFader } from "@features/effects/ui/VerticalFader";
 import { glassBackground } from "@shared/styles/glassBackground";
 import { TopNav } from "@widgets/top-nav/ui/TopNav";
+import { TopPlaybackBar } from "@widgets/top-playback-bar";
 
 
 const LABELS: EffectKey[] = ["CRUSH", "COMB", "HICUT", "LOWCUT", "REVERB", "DIRTY"];
@@ -56,6 +57,7 @@ export const PlayPage = () => {
     <div css={glassBackground}>
       {/* ナビゲーション */}
       <TopNav />
+      <TopPlaybackBar />
       <Faders />
     </div>
   );

--- a/client/src/pages/play/ui/PlayPage.tsx
+++ b/client/src/pages/play/ui/PlayPage.tsx
@@ -24,7 +24,8 @@ const Faders = () => {
         boxShadow: "0 8px 16px 0 rgba(31, 38, 135, 0.37)",
         background: "linear-gradient(135deg, rgba(255,255,255,0.35), rgba(140,194,209,0.25))",
         padding: 16,
-        marginTop: 12,
+        width: 600,
+        margin: "12px auto 0",
       }}
     >
       <div css={{ display: "flex", gap: "12px", alignItems: "flex-end", justifyContent: "center" }}>

--- a/client/src/pages/rhythm/ui/RhythmPage.tsx
+++ b/client/src/pages/rhythm/ui/RhythmPage.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { glassBackground } from "@shared/styles/glassBackground";
 import { TopNav } from "@widgets/top-nav/ui/TopNav";
+import { TopPlaybackBar } from "@widgets/top-playback-bar";
 
 export const RhythmPage = () => {
 
@@ -8,7 +9,7 @@ export const RhythmPage = () => {
     <div css={glassBackground}>
       {/* ナビゲーション */}
       <TopNav />
+      <TopPlaybackBar />
     </div>
   );
 };
-

--- a/client/src/shared/ui/RectButton.tsx
+++ b/client/src/shared/ui/RectButton.tsx
@@ -7,6 +7,8 @@ import styled from '@emotion/styled';
 export const StyledButton = styled.button<{
   active?: boolean;
   flexGrow?: number | string;
+  widthPx?: number | string;
+  minWidthPx?: number | string;
 }>`
   box-sizing: border-box;
   font-family: "brandon-grotesque", sans-serif;
@@ -14,6 +16,8 @@ export const StyledButton = styled.button<{
   font-style: normal;
   font-size:14px;
   flex: ${({ flexGrow }) => flexGrow ?? '0 1 auto'};
+  ${({ widthPx }) => (widthPx != null ? `width: ${typeof widthPx === 'number' ? `${widthPx}px` : widthPx};` : '')}
+  ${({ minWidthPx }) => (minWidthPx != null ? `min-width: ${typeof minWidthPx === 'number' ? `${minWidthPx}px` : minWidthPx};` : '')}
   background: ${({ active }) =>
     active
       ? 'linear-gradient(135deg, rgba(172, 203, 229, 0.45), rgba(165, 178, 220, 0.74))'
@@ -47,16 +51,19 @@ export const RectButton = ({
   active,
   onClick,
   flexGrow,
+  widthPx,
+  minWidthPx,
 }: {
   label: string;
   active?: boolean;
   onClick?: () => void;
   flexGrow?: number | string;
+  widthPx?: number | string;
+  minWidthPx?: number | string;
 }) => {
   return (
-    <StyledButton active={active} onClick={onClick} flexGrow={flexGrow}>
+    <StyledButton active={active} onClick={onClick} flexGrow={flexGrow} widthPx={widthPx} minWidthPx={minWidthPx}>
       {label}
     </StyledButton>
   );
 };
-

--- a/client/src/widgets/top-playback-bar/index.ts
+++ b/client/src/widgets/top-playback-bar/index.ts
@@ -1,0 +1,2 @@
+export { TopPlaybackBar } from './ui/TopPlaybackBar';
+

--- a/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
+++ b/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
@@ -46,10 +46,20 @@ export const TopPlaybackBar = () => {
   const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const loopLen = Tone.Time('2m').toSeconds();
     const tick = () => {
-      const t = Tone.getTransport().seconds;
-      const r = loopLen > 0 ? ((t % loopLen) / loopLen) : 0;
+      // 進捗は楽譜時間ベースで算出（テンポ変更に頑強）
+      const pos = Tone.getTransport().position as unknown as string; // "bars:beats:sixteenths"
+      const [barsStr, beatsStr, sixStr] = (pos || '0:0:0').split(':');
+      const bars = Number(barsStr) || 0;
+      const beats = Number(beatsStr) || 0;
+      const six = Number(sixStr) || 0;
+      // timeSignature（拍子）を考慮（デフォルト4/4）
+      // @ts-ignore
+      const ts = (Tone.getTransport().timeSignature ?? 4) as number | [number, number];
+      const beatsPerBar = Array.isArray(ts) ? ts[0] : ts;
+      const totalBeats = bars * beatsPerBar + beats + six / 4;
+      const loopBeats = beatsPerBar * 2; // 2小節ループ
+      const r = loopBeats > 0 ? ((totalBeats % loopBeats) / loopBeats) : 0;
       setRatio(r);
       rafRef.current = requestAnimationFrame(tick);
     };
@@ -66,7 +76,7 @@ export const TopPlaybackBar = () => {
 
   return (
     <BarWrapper>
-      <RectButton onClick={onToggle} label={isLoopPlaying ? '■ Stop' : '▶︎ Play'} />
+      <RectButton onClick={onToggle} label={isLoopPlaying ? '⏸ Pause' : '▶︎ Play'} />
       <ProgressWrap aria-label="loop progress">
         <ProgressDot x={ratio} />
       </ProgressWrap>

--- a/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
+++ b/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
@@ -17,7 +17,7 @@ const BarWrapper = styled.div`
   margin: 10px auto;
   padding: 10px 12px;
   max-width: 600px;
-  background: linear-gradient(135deg, rgba(255,255,255,0.35), rgba(140,194,209,0.25));
+  background: linear-gradient(135deg, rgba(255,255,255,0.35), rgba(140, 194, 209, 0.843));
   box-shadow: 0 8px 16px 0 rgba(31, 38, 135, 0.37);
 `;
 
@@ -28,6 +28,9 @@ const ProgressWrap = styled.div`
   border-radius: 999px;
   background:linear-gradient(90deg, rgb(255, 135, 22), rgb(255, 17, 195));
   overflow: visible;
+  user-select: none;
+  touch-action: none;
+  cursor: pointer;
 `;
 
 const ProgressDot = styled.div<{ x: number }>`
@@ -58,22 +61,57 @@ export const TopPlaybackBar = () => {
   const [ratio, setRatio] = useState(0);
   const rafRef = useRef<number | null>(null);
 
+  // スクラブ中はrAFからの上書きを止める
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const isScrubbingRef = useRef(false);
+  useEffect(() => { isScrubbingRef.current = isScrubbing; }, [isScrubbing]);
+
+  const progressRef = useRef<HTMLDivElement | null>(null);
+
+  const getBeatsPerBar = () => {
+    // @ts-ignore
+    const ts = (Tone.getTransport().timeSignature ?? 4) as number | [number, number];
+    return Array.isArray(ts) ? ts[0] : ts;
+  };
+
+  const ratioToPositionString = (r: number) => {
+    const beatsPerBar = getBeatsPerBar();
+    const loopBeats = beatsPerBar * 2; // 2小節ループ
+    // 末端で1ちょうどにならないようにクランプ
+    const totalBeats = Math.max(0, Math.min(loopBeats - 1e-6, r * loopBeats));
+    const bars = Math.floor(totalBeats / beatsPerBar);
+    const beatInBar = totalBeats - bars * beatsPerBar; // 0..(<beatsPerBar)
+    const beats = Math.floor(beatInBar);
+    const six = Math.round((beatInBar - beats) * 4); // 16分単位（0..3）
+    return `${bars}:${beats}:${six}`;
+  };
+
+  const updateRatioFromClientX = (clientX: number) => {
+    const el = progressRef.current;
+    if (!el) return 0;
+    const rect = el.getBoundingClientRect();
+    const r = rect.width > 0 ? (clientX - rect.left) / rect.width : 0;
+    const clamped = Math.max(0, Math.min(1, r));
+    setRatio(clamped);
+    return clamped;
+  };
+
   useEffect(() => {
     const tick = () => {
-      // 進捗は楽譜時間ベースで算出（テンポ変更に頑強）
-      const pos = Tone.getTransport().position as unknown as string; // "bars:beats:sixteenths"
-      const [barsStr, beatsStr, sixStr] = (pos || '0:0:0').split(':');
-      const bars = Number(barsStr) || 0;
-      const beats = Number(beatsStr) || 0;
-      const six = Number(sixStr) || 0;
-      // timeSignature（拍子）を考慮（デフォルト4/4）
-      // @ts-ignore
-      const ts = (Tone.getTransport().timeSignature ?? 4) as number | [number, number];
-      const beatsPerBar = Array.isArray(ts) ? ts[0] : ts;
-      const totalBeats = bars * beatsPerBar + beats + six / 4;
-      const loopBeats = beatsPerBar * 2; // 2小節ループ
-      const r = loopBeats > 0 ? ((totalBeats % loopBeats) / loopBeats) : 0;
-      setRatio(r);
+      if (!isScrubbingRef.current) {
+        // 進捗は楽譜時間ベースで算出（テンポ変更に頑強）
+        const pos = Tone.getTransport().position as unknown as string; // "bars:beats:sixteenths"
+        const [barsStr, beatsStr, sixStr] = (pos || '0:0:0').split(':');
+        const bars = Number(barsStr) || 0;
+        const beats = Number(beatsStr) || 0;
+        const six = Number(sixStr) || 0;
+        // timeSignature（拍子）
+        const beatsPerBar = getBeatsPerBar();
+        const totalBeats = bars * beatsPerBar + beats + six / 4;
+        const loopBeats = beatsPerBar * 2; // 2小節ループ
+        const r = loopBeats > 0 ? ((totalBeats % loopBeats) / loopBeats) : 0;
+        setRatio(r);
+      }
       rafRef.current = requestAnimationFrame(tick);
     };
     if (isLoopPlaying) {
@@ -81,6 +119,31 @@ export const TopPlaybackBar = () => {
     }
     return () => { if (rafRef.current != null) cancelAnimationFrame(rafRef.current); rafRef.current = null; };
   }, [isLoopPlaying]);
+
+  // Pointer handlers for scrubbing
+  function onPointerDown(e: any) {
+    setIsScrubbing(true);
+    e.currentTarget?.setPointerCapture?.(e.pointerId);
+    updateRatioFromClientX(e.clientX);
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', onPointerUp);
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!isScrubbingRef.current) return;
+    updateRatioFromClientX(e.clientX);
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (!isScrubbingRef.current) return;
+    setIsScrubbing(false);
+    const r = updateRatioFromClientX(e.clientX);
+    const posString = ratioToPositionString(r);
+    // @ts-ignore: Tone typings
+    (Tone.getTransport() as any).position = posString; // 再生中/停止中どちらでもシーク
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+  }
 
   const onToggle = async () => {
     if (isLoopPlaying) stop();
@@ -93,7 +156,15 @@ export const TopPlaybackBar = () => {
       <ControlsRow>
         <RectButton onClick={onToggle} label={isLoopPlaying ? '⏸ Pause' : '▶︎ Play'} widthPx={70} />
         <RectButton onClick={onStop} label={'■ Stop'} widthPx={70} />
-        <ProgressWrap aria-label="loop progress">
+        <ProgressWrap
+          ref={progressRef}
+          aria-label="loop progress"
+          role="slider"
+          aria-valuemin={0}
+          aria-valuemax={1}
+          aria-valuenow={Number(ratio.toFixed(3))}
+          onPointerDown={onPointerDown}
+        >
           <ProgressDot x={ratio} />
         </ProgressWrap>
       </ControlsRow>

--- a/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
+++ b/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
@@ -41,7 +41,7 @@ const ProgressDot = styled.div<{ x: number }>`
 `;
 
 export const TopPlaybackBar = () => {
-  const { loopPlay, stop, isLoopPlaying } = usePlaybackController();
+  const { loopPlay, stop, reset, isLoopPlaying } = usePlaybackController();
   const [ratio, setRatio] = useState(0);
   const rafRef = useRef<number | null>(null);
 
@@ -73,10 +73,12 @@ export const TopPlaybackBar = () => {
     if (isLoopPlaying) stop();
     else await loopPlay();
   };
+  const onStop = () => { reset(); setRatio(0); };
 
   return (
     <BarWrapper>
-      <RectButton onClick={onToggle} label={isLoopPlaying ? '⏸ Pause' : '▶︎ Play'} />
+      <RectButton onClick={onToggle} label={isLoopPlaying ? '⏸ Pause' : '▶︎ Play'} widthPx={70} />
+      <RectButton onClick={onStop} label={'■ Stop'} widthPx={70} />
       <ProgressWrap aria-label="loop progress">
         <ProgressDot x={ratio} />
       </ProgressWrap>

--- a/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
+++ b/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
@@ -1,16 +1,75 @@
+import styled from '@emotion/styled';
+import { useEffect, useRef, useState } from 'react';
+import * as Tone from 'tone';
 import { RectButton } from '@shared/ui/RectButton';
 import { usePlaybackController } from '@features/playback/model/usePlaybackController';
 
+const BarWrapper = styled.div`
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 10px auto;
+  padding: 10px 12px;
+  max-width: 600px;
+  background: linear-gradient(135deg, rgba(255,255,255,0.35), rgba(140,194,209,0.25));
+  box-shadow: 0 8px 16px 0 rgba(31, 38, 135, 0.37);
+`;
+
+const ProgressWrap = styled.div`
+  position: relative;
+  height: 4px;
+  flex: 1;
+  border-radius: 999px;
+  background:linear-gradient(90deg, rgb(255, 135, 22), rgb(255, 17, 195));
+  overflow: visible;
+`;
+
+const ProgressDot = styled.div<{ x: number }>`
+  position: absolute;
+  left: ${({ x }) => `${x * 100}%`};
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ff2a2a;
+  box-shadow: 0 0 0 2px rgba(255, 42, 42, 0.25);
+`;
+
 export const TopPlaybackBar = () => {
   const { loopPlay, stop, isLoopPlaying } = usePlaybackController();
+  const [ratio, setRatio] = useState(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const loopLen = Tone.Time('2m').toSeconds();
+    const tick = () => {
+      const t = Tone.getTransport().seconds;
+      const r = loopLen > 0 ? ((t % loopLen) / loopLen) : 0;
+      setRatio(r);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    if (isLoopPlaying) {
+      rafRef.current = requestAnimationFrame(tick);
+    }
+    return () => { if (rafRef.current != null) cancelAnimationFrame(rafRef.current); rafRef.current = null; };
+  }, [isLoopPlaying]);
+
   const onToggle = async () => {
     if (isLoopPlaying) stop();
     else await loopPlay();
   };
+
   return (
-
-    <RectButton onClick={onToggle} label={isLoopPlaying ? '■ Stop Music' : '▶︎ Play Music'} />
-
+    <BarWrapper>
+      <RectButton onClick={onToggle} label={isLoopPlaying ? '■ Stop' : '▶︎ Play'} />
+      <ProgressWrap aria-label="loop progress">
+        <ProgressDot x={ratio} />
+      </ProgressWrap>
+    </BarWrapper>
   );
 };
-

--- a/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
+++ b/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
@@ -4,6 +4,7 @@ import * as Tone from 'tone';
 import { RectButton } from '@shared/ui/RectButton';
 import { usePlaybackController } from '@features/playback/model/usePlaybackController';
 import { TempoControl } from '@features/tempo';
+import { VolumeControl } from '@features/volume';
 
 const BarWrapper = styled.div`
   backdrop-filter: blur(20px);
@@ -53,7 +54,7 @@ const ControlsRow = styled.div`
 
 const TempoRow = styled.div`
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
 `;
 
 export const TopPlaybackBar = () => {
@@ -169,8 +170,11 @@ export const TopPlaybackBar = () => {
         </ProgressWrap>
       </ControlsRow>
       <TempoRow>
-        <div style={{ width: 200 }}>
+        <div style={{ width: 140 }}>
           <TempoControl />
+        </div>
+        <div style={{ width: 120 }}>
+          <VolumeControl />
         </div>
       </TempoRow>
     </BarWrapper>

--- a/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
+++ b/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import * as Tone from 'tone';
 import { RectButton } from '@shared/ui/RectButton';
 import { usePlaybackController } from '@features/playback/model/usePlaybackController';
-import { TempoControlButton } from '@features/tempo';
+import { TempoControl } from '@features/tempo';
 
 const BarWrapper = styled.div`
   backdrop-filter: blur(20px);
@@ -57,7 +57,6 @@ export const TopPlaybackBar = () => {
   const { loopPlay, stop, reset, isLoopPlaying } = usePlaybackController();
   const [ratio, setRatio] = useState(0);
   const rafRef = useRef<number | null>(null);
-  const [tempoControlOpen, setTempoControlOpen] = useState(false);
 
   useEffect(() => {
     const tick = () => {
@@ -99,8 +98,8 @@ export const TopPlaybackBar = () => {
         </ProgressWrap>
       </ControlsRow>
       <TempoRow>
-        <div style={{ width: 160 }}>
-          <TempoControlButton isOpen={tempoControlOpen} onToggle={() => setTempoControlOpen((prev) => !prev)} />
+        <div style={{ width: 200 }}>
+          <TempoControl />
         </div>
       </TempoRow>
     </BarWrapper>

--- a/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
+++ b/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
@@ -1,0 +1,16 @@
+import { RectButton } from '@shared/ui/RectButton';
+import { usePlaybackController } from '@features/playback/model/usePlaybackController';
+
+export const TopPlaybackBar = () => {
+  const { loopPlay, stop, isLoopPlaying } = usePlaybackController();
+  const onToggle = async () => {
+    if (isLoopPlaying) stop();
+    else await loopPlay();
+  };
+  return (
+
+    <RectButton onClick={onToggle} label={isLoopPlaying ? '■ Stop Music' : '▶︎ Play Music'} />
+
+  );
+};
+

--- a/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
+++ b/client/src/widgets/top-playback-bar/ui/TopPlaybackBar.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import * as Tone from 'tone';
 import { RectButton } from '@shared/ui/RectButton';
 import { usePlaybackController } from '@features/playback/model/usePlaybackController';
+import { TempoControlButton } from '@features/tempo';
 
 const BarWrapper = styled.div`
   backdrop-filter: blur(20px);
@@ -10,7 +11,8 @@ const BarWrapper = styled.div`
   border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 12px;
   margin: 10px auto;
   padding: 10px 12px;
@@ -40,10 +42,22 @@ const ProgressDot = styled.div<{ x: number }>`
   box-shadow: 0 0 0 2px rgba(255, 42, 42, 0.25);
 `;
 
+const ControlsRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const TempoRow = styled.div`
+  display: flex;
+  justify-content: flex-start;
+`;
+
 export const TopPlaybackBar = () => {
   const { loopPlay, stop, reset, isLoopPlaying } = usePlaybackController();
   const [ratio, setRatio] = useState(0);
   const rafRef = useRef<number | null>(null);
+  const [tempoControlOpen, setTempoControlOpen] = useState(false);
 
   useEffect(() => {
     const tick = () => {
@@ -77,11 +91,18 @@ export const TopPlaybackBar = () => {
 
   return (
     <BarWrapper>
-      <RectButton onClick={onToggle} label={isLoopPlaying ? '⏸ Pause' : '▶︎ Play'} widthPx={70} />
-      <RectButton onClick={onStop} label={'■ Stop'} widthPx={70} />
-      <ProgressWrap aria-label="loop progress">
-        <ProgressDot x={ratio} />
-      </ProgressWrap>
+      <ControlsRow>
+        <RectButton onClick={onToggle} label={isLoopPlaying ? '⏸ Pause' : '▶︎ Play'} widthPx={70} />
+        <RectButton onClick={onStop} label={'■ Stop'} widthPx={70} />
+        <ProgressWrap aria-label="loop progress">
+          <ProgressDot x={ratio} />
+        </ProgressWrap>
+      </ControlsRow>
+      <TempoRow>
+        <div style={{ width: 160 }}>
+          <TempoControlButton isOpen={tempoControlOpen} onToggle={() => setTempoControlOpen((prev) => !prev)} />
+        </div>
+      </TempoRow>
     </BarWrapper>
   );
 };

--- a/client/src/widgets/waveform/ui/WaveformDisplay.tsx
+++ b/client/src/widgets/waveform/ui/WaveformDisplay.tsx
@@ -116,6 +116,13 @@ export const WaveformDisplay = ({ audioBlob }: Props) => {
 
   // 再生/停止は TopPlaybackBar に移動
 
+  // 分析完了までは選択中アレイのUI全体を非表示にする
+  const hasSelectedSegments = loopMode === 'melody'
+    ? melodySegments.length > 0
+    : loopMode === 'rhythm'
+      ? rhythmSegments.length > 0
+      : (melodySegments.length > 0 || rhythmSegments.length > 0);
+
   return (
     <CenteredArea>
       <RecordingBeatIndicator currentBar={currentBar} currentBeat={currentBeat} />
@@ -131,7 +138,7 @@ export const WaveformDisplay = ({ audioBlob }: Props) => {
         )}
       </WaveformArea>
 
-      {Array.from({ length: barCount }).map((_, barIndex) => (
+      {hasSelectedSegments && Array.from({ length: barCount }).map((_, barIndex) => (
         <div style={{ height: '220px' }} key={barIndex}>
           <BarWaveformContainer>
             {loopMode === 'both' ? (

--- a/client/src/widgets/waveform/ui/WaveformDisplay.tsx
+++ b/client/src/widgets/waveform/ui/WaveformDisplay.tsx
@@ -11,7 +11,6 @@ import { ChordPatternSelect, DrumPatternSelect } from '@features/pattern-select'
 import { useDrumLoopScheduler, useMelodyLoopScheduler, useChordsLoopScheduler as useChordLoopScheduler } from '@features/playback';
 import { RecordingBeatIndicator } from '@features/recording';
 import { RhythmSegmentEditor, MelodySegmentEditor } from '@features/segment-edit';
-import { TempoControlButton } from '@features/tempo';
 import { WaveformViewer } from '@features/waveform';
 import { StyledArea } from '@shared/ui';
 
@@ -57,7 +56,6 @@ const SegmentLabel = styled(StyledArea)`
 type Props = { audioBlob: Blob | null };
 
 export const WaveformDisplay = ({ audioBlob }: Props) => {
-  const [tempoControlOpen, setTempoControlOpen] = useState(false);
   const { currentBar, currentBeat } = useCountBarsAndBeats();
   const { currentSegments, loopMode, rhythmSegments, melodySegments, setContextAudioBuffer } = useSegment();
   const { isRecording } = useRecording();
@@ -125,12 +123,6 @@ export const WaveformDisplay = ({ audioBlob }: Props) => {
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '12px' }}>
         <ChordPatternSelect />
         <DrumPatternSelect />
-      </div>
-
-      <div style={{ display: 'flex', justifyContent: 'center', marginTop: '8px' }}>
-        <div style={{ display: 'flex', justifyContent: 'center', width: '160px' }}>
-          <TempoControlButton isOpen={tempoControlOpen} onToggle={() => setTempoControlOpen((prev) => !prev)} />
-        </div>
       </div>
 
       <WaveformArea ref={waveformRef} isRed={isRed}>

--- a/client/src/widgets/waveform/ui/WaveformDisplay.tsx
+++ b/client/src/widgets/waveform/ui/WaveformDisplay.tsx
@@ -59,7 +59,7 @@ type Props = { audioBlob: Blob | null };
 export const WaveformDisplay = ({ audioBlob }: Props) => {
   const [tempoControlOpen, setTempoControlOpen] = useState(false);
   const { currentBar, currentBeat } = useCountBarsAndBeats();
-  const { currentSegments, loopMode, rhythmSegments, melodySegments, audioBuffers } = useSegment();
+  const { currentSegments, loopMode, rhythmSegments, melodySegments, setContextAudioBuffer } = useSegment();
   const { isRecording } = useRecording();
   const canvasRef = useAnalyser();
   const { tempo } = useTempo();
@@ -74,9 +74,8 @@ export const WaveformDisplay = ({ audioBlob }: Props) => {
 
   useEffect(() => {
     if (!audioBuffer) return;
-    if (loopMode === 'rhythm') audioBuffers.rhythm = audioBuffer;
-    else if (loopMode === 'melody') audioBuffers.melody = audioBuffer;
-  }, [audioBuffer, loopMode, audioBuffers]);
+    setContextAudioBuffer(loopMode === 'rhythm' ? 'rhythm' : 'melody', audioBuffer);
+  }, [audioBuffer, loopMode, setContextAudioBuffer]);
 
   const waveformRef = useRef<HTMLDivElement>(null);
   const waveformLeftRef = useRef(0);
@@ -140,7 +139,7 @@ export const WaveformDisplay = ({ audioBlob }: Props) => {
         )}
       </WaveformArea>
 
-      {audioBuffer && Array.from({ length: barCount }).map((_, barIndex) => (
+      {Array.from({ length: barCount }).map((_, barIndex) => (
         <div style={{ height: '220px' }} key={barIndex}>
           <BarWaveformContainer>
             {loopMode === 'both' ? (

--- a/client/src/widgets/waveform/ui/WaveformDisplay.tsx
+++ b/client/src/widgets/waveform/ui/WaveformDisplay.tsx
@@ -8,12 +8,12 @@ import { useCountBarsAndBeats } from '@entities/count-bars-and-beats';
 import { useSegment } from '@entities/segment';
 import { useTempo } from '@entities/tempo';
 import { ChordPatternSelect, DrumPatternSelect } from '@features/pattern-select';
-import { useDrumLoopScheduler, useMelodyLoopScheduler, useChordsLoopScheduler as useChordLoopScheduler, usePlaybackController } from '@features/playback';
+import { useDrumLoopScheduler, useMelodyLoopScheduler, useChordsLoopScheduler as useChordLoopScheduler } from '@features/playback';
 import { RecordingBeatIndicator } from '@features/recording';
 import { RhythmSegmentEditor, MelodySegmentEditor } from '@features/segment-edit';
 import { TempoControlButton } from '@features/tempo';
 import { WaveformViewer } from '@features/waveform';
-import { RectButton, StyledArea } from '@shared/ui';
+import { StyledArea } from '@shared/ui';
 
 export const CenteredArea = styled(StyledArea)`
   flex-direction: column;
@@ -68,7 +68,7 @@ export const WaveformDisplay = ({ audioBlob }: Props) => {
   useDrumLoopScheduler();
   useMelodyLoopScheduler();
 
-  const { loopPlay, stop, isLoopPlaying } = usePlaybackController();
+  // 再生/停止は TopPlaybackBar に移動したため、ここでは未使用
   const { barCount } = useBarCount();
   const audioBuffer = useAudioBuffer(audioBlob);
 
@@ -117,7 +117,7 @@ export const WaveformDisplay = ({ audioBlob }: Props) => {
     }
   }, [currentBuffer]);
 
-  const handleToggleLoop = async () => { if (isLoopPlaying) { stop(); } else { await loopPlay(); } };
+  // 再生/停止は TopPlaybackBar に移動
 
   return (
     <CenteredArea>
@@ -129,9 +129,6 @@ export const WaveformDisplay = ({ audioBlob }: Props) => {
       </div>
 
       <div style={{ display: 'flex', justifyContent: 'center', marginTop: '8px' }}>
-        <div style={{ display: 'flex', justifyContent: 'center', width: '160px' }}>
-          <RectButton onClick={handleToggleLoop} label={isLoopPlaying ? '■ Stop Music' : '▶︎ Play Music'} />
-        </div>
         <div style={{ display: 'flex', justifyContent: 'center', width: '160px' }}>
           <TempoControlButton isOpen={tempoControlOpen} onToggle={() => setTempoControlOpen((prev) => !prev)} />
         </div>


### PR DESCRIPTION
# 更新内容

## 🎵 再生機能
- **PlaybackButtonの配置を変更**  
  - 画面上部に全画面共通のUIとして **TopPlaybackBar** を追加
- **再生停止機能の仕様を変更**  
  - Play/Stop ボタンを **Play/Pause ボタン** と **Stop ボタン** に分離
- **再生停止機能の仕様修正**  
  - **Pause / Stop ボタン** を押した瞬間にサウンドの再生が停止するよう修正
- **再生バーを追加**  
  - スクラブ操作で再生地点を変更可能

## 🔊 音量・テンポ
- **Volume 調節 UI を追加**  
  - ロジック実装済み
- **Tempo 調節 UI を変更**  
  - ボタンを廃止し、**TopPlaybackBar** にスライダー UI を直書き

## 🎛 エフェクト編集
- **Effects の各種編集機能追加**  
  - `HOLD` / `RESET` / `RANDOMIZE` 機能を追加

## 🎹 サウンド操作
- **MUTE / UNMUTE 機能を追加**  
  - `MELODY` / `CHORD` / `DRUM` で個別に操作可能